### PR TITLE
Added support for server relative links without servlet API (WebContext)

### DIFF
--- a/src/main/java/org/thymeleaf/standard/expression/LinkExpression.java
+++ b/src/main/java/org/thymeleaf/standard/expression/LinkExpression.java
@@ -235,9 +235,9 @@ public final class LinkExpression extends SimpleExpression {
 
         String linkBase = (String) base;
         
-        if (!isWebContext(arguments.getContext()) && isLinkBaseServerRelative(linkBase)) {
+        if (!isLinkBaseAbsolute(linkBase) && !isWebContext(arguments.getContext()) && !isLinkBaseServerRelative(linkBase)) {
             throw new TemplateProcessingException(
-                    "Link base \"" + linkBase + "\" cannot be server relative (~/) unless you implement the " + 
+                    "Link base \"" + linkBase + "\" cannot be context relative (/) unless you implement the " + 
                     IWebContext.class.getName() + " interface (context is of class: " +
                     arguments.getContext().getClass().getName() + ")");
         }
@@ -313,9 +313,11 @@ public final class LinkExpression extends SimpleExpression {
             
         }
         
-        if (isLinkBaseAbsolute(linkBase) || !isWebContext(arguments.getContext()) && isLinkBaseContextRelative(linkBase)) {
-            return linkBase + parametersBuffer.toString() + urlFragment;
-        }
+		if (isLinkBaseAbsolute(linkBase)) {
+			return linkBase + parametersBuffer.toString() + urlFragment;
+		} else if (!isWebContext(arguments.getContext()) && isLinkBaseServerRelative(linkBase)) {
+			return linkBase.substring(1) + parametersBuffer.toString() + urlFragment;
+		}
         
         final IWebContext webContext = (IWebContext) arguments.getContext();
         

--- a/src/main/java/org/thymeleaf/standard/expression/LinkExpression.java
+++ b/src/main/java/org/thymeleaf/standard/expression/LinkExpression.java
@@ -313,11 +313,11 @@ public final class LinkExpression extends SimpleExpression {
             
         }
         
-		if (isLinkBaseAbsolute(linkBase)) {
-			return linkBase + parametersBuffer.toString() + urlFragment;
-		} else if (!isWebContext(arguments.getContext()) && isLinkBaseServerRelative(linkBase)) {
-			return linkBase.substring(1) + parametersBuffer.toString() + urlFragment;
-		}
+        if (isLinkBaseAbsolute(linkBase)) {
+            return linkBase + parametersBuffer.toString() + urlFragment;
+        } else if (!isWebContext(arguments.getContext()) && isLinkBaseServerRelative(linkBase)) {
+            return linkBase.substring(1) + parametersBuffer.toString() + urlFragment;
+        }
         
         final IWebContext webContext = (IWebContext) arguments.getContext();
         

--- a/src/main/java/org/thymeleaf/standard/expression/LinkExpression.java
+++ b/src/main/java/org/thymeleaf/standard/expression/LinkExpression.java
@@ -235,10 +235,9 @@ public final class LinkExpression extends SimpleExpression {
 
         String linkBase = (String) base;
         
-        if (!isWebContext(arguments.getContext()) && !isLinkBaseAbsolute(linkBase)) {
+        if (!isWebContext(arguments.getContext()) && isLinkBaseServerRelative(linkBase)) {
             throw new TemplateProcessingException(
-                    "Link base \"" + linkBase + "\" is not absolute. Non-absolute links " +
-                    "can only be processed if context implements the " + 
+                    "Link base \"" + linkBase + "\" cannot be server relative (~/) unless you implement the " + 
                     IWebContext.class.getName() + " interface (context is of class: " +
                     arguments.getContext().getClass().getName() + ")");
         }
@@ -314,7 +313,7 @@ public final class LinkExpression extends SimpleExpression {
             
         }
         
-        if (isLinkBaseAbsolute(linkBase)) {
+        if (isLinkBaseAbsolute(linkBase) || !isWebContext(arguments.getContext()) && isLinkBaseContextRelative(linkBase)) {
             return linkBase + parametersBuffer.toString() + urlFragment;
         }
         

--- a/src/test/java/org/thymeleaf/standard/expression/ExpressionTest.java
+++ b/src/test/java/org/thymeleaf/standard/expression/ExpressionTest.java
@@ -219,6 +219,9 @@ public class ExpressionTest extends TestCase {
         test("@{http://a.b.com/xx/yy(p1, p2=${pamerica.name})}", "http://a.b.com/xx/yy?p1&amp;p2=Petronila+America");
         test("@{http://a.b.com/xx/yy(p1='zz', p2)}", "http://a.b.com/xx/yy?p1=zz&amp;p2");
         test("@{http://a.b.com/xx/yy(p1, p2)}", "http://a.b.com/xx/yy?p1&amp;p2");
+        test("@{/xx/yy}", "/xx/yy");
+        test("@{/xx/yy(p1)}", "/xx/yy?p1");
+        test("@{/xx/yy(p1, p2=${pamerica.name})}", "/xx/yy?p1&amp;p2=Petronila+America");
     
     }
 

--- a/src/test/java/org/thymeleaf/standard/expression/ExpressionTest.java
+++ b/src/test/java/org/thymeleaf/standard/expression/ExpressionTest.java
@@ -219,9 +219,9 @@ public class ExpressionTest extends TestCase {
         test("@{http://a.b.com/xx/yy(p1, p2=${pamerica.name})}", "http://a.b.com/xx/yy?p1&amp;p2=Petronila+America");
         test("@{http://a.b.com/xx/yy(p1='zz', p2)}", "http://a.b.com/xx/yy?p1=zz&amp;p2");
         test("@{http://a.b.com/xx/yy(p1, p2)}", "http://a.b.com/xx/yy?p1&amp;p2");
-        test("@{/xx/yy}", "/xx/yy");
-        test("@{/xx/yy(p1)}", "/xx/yy?p1");
-        test("@{/xx/yy(p1, p2=${pamerica.name})}", "/xx/yy?p1&amp;p2=Petronila+America");
+        test("@{~/xx/yy}", "/xx/yy");
+        test("@{~/xx/yy(p1)}", "/xx/yy?p1");
+        test("@{~/xx/yy(p1, p2=${pamerica.name})}", "/xx/yy?p1&amp;p2=Petronila+America");
     
     }
 


### PR DESCRIPTION
Allows the usage of @{~/urls} in non-servlet containers. Originally submitted in issue #4 and #5, but now changed.

I've tested with my cookies disabled and enabled on a Tomcat7 servlet container using the first Thymeleaf example. There I have tested absolute, context / and server ~/ relative urls. All working great.

On my own non servlet based solution I've tested absolute (works), context / (fails, as it should) and server ~/ (works). I also don't have any jsessionid appended to my non-servlet solution.

Also tested out some bogus urls, like @{b/}, and that will fail as well.
