### PR TITLE
Allow changing of the DocType

### DIFF
--- a/src/main/java/org/thymeleaf/dom/Document.java
+++ b/src/main/java/org/thymeleaf/dom/Document.java
@@ -69,7 +69,10 @@ public final class Document extends NestableNode {
     public boolean hasDocType() {
         return this.docType != null;
     }
-    
+
+    public void setDocType(DocType docType) {
+    	this.docType = docType;
+    }
 
 
     @Override


### PR DESCRIPTION
Now that Thymeleaf doesn't require full HTML pages, I've been asked to be able to support the same with my dialect, meaning I could encounter cases like this:

```
<p layout:decorator="Layout.html" layout:fragment="custom-paragraph">
  This is some paragraph text.
</p>
```

I've made changes to support such cases just fine, but the resulting page lacks a doctype.  The decorator does have a doctype but I can't copy it over because the `org.thymeleaf.dom.Document` class lacks a method to change it.

This pull request just adds a `setDocType` method to the `Document` class, allowing this test case to pass.

Are there any issues with changing the doctype though?
