### PR TITLE
New utility methods for #strings

### DIFF
--- a/src/main/java/org/thymeleaf/expression/Strings.java
+++ b/src/main/java/org/thymeleaf/expression/Strings.java
@@ -181,6 +181,21 @@ public final class Strings {
 
     
     
+    /**
+     * 
+     * @since 2.0.16
+     */
+    public Boolean equals(final Object target, final String string) {
+        return StringUtils.equals(target, string);
+    }
+    
+    /**
+     * 
+     * @since 2.0.16
+     */
+    public Boolean equalsIgnoreCase(final Object target, final String string) {
+        return StringUtils.equalsIgnoreCase(target, string);
+    }
     
     
     public Boolean contains(final Object target, final String fragment) {
@@ -564,6 +579,14 @@ public final class Strings {
         return StringUtils.append(target, suffix);
     }
     
+    /**
+     * 
+     * @since 2.0.16
+     */
+    public String concat(final Object target, final String nullValue, final String ... strings) {
+        return StringUtils.concat(target, nullValue, strings);
+    }
+        
     public String[] arrayAppend(final Object[] target, final String suffix) {
         Validate.notNull(target, "Target cannot be null");
         final String[] result = new String[target.length];

--- a/src/main/java/org/thymeleaf/util/StringUtils.java
+++ b/src/main/java/org/thymeleaf/util/StringUtils.java
@@ -43,6 +43,7 @@ import java.util.StringTokenizer;
  * 
  * @author Daniel Fern&aacute;ndez
  * @author Le Roux Bernard
+ * @author Soraya S&aacute;nchez Labandeira
  * 
  * @since 1.0
  *
@@ -93,6 +94,35 @@ public final class StringUtils {
     
     
 
+    /**
+     * 
+     * @since 2.0.16
+     */
+    public static Boolean equals(final Object target, String string) {
+        
+        if (target == null && string == null) {
+            return Boolean.TRUE;
+        }
+        if (target == null || string == null) {
+            return Boolean.FALSE;
+        }
+        return Boolean.valueOf(target.toString().equals(string));
+        
+    }
+    
+    /**
+     * 
+     * @since 2.0.16
+     */
+    public static Boolean equalsIgnoreCase(final Object target, String string) {
+        if (target == null && string == null) {
+            return Boolean.TRUE;
+        }
+        if (target == null || string == null) {
+            return Boolean.FALSE;
+        }
+        return Boolean.valueOf(target.toString().toUpperCase().equals(string.toUpperCase()));
+    }
     
     public static Boolean contains(final Object target, final String fragment) {
         
@@ -242,9 +272,31 @@ public final class StringUtils {
         return target + suffix;
     }
 
-    
-    
-    
+    /**
+     * 
+     * @since 2.0.16
+     */
+    public static String concat(final Object target, final String nullValue, final String ... strings) {
+        
+        final StringBuilder sb = new StringBuilder();
+        
+        if (target == null) {
+            sb.append(nullValue);
+        } else {
+            sb.append(target);
+        }
+        for (String string : strings) {
+            if (string == null) {
+                sb.append(nullValue);
+            } else {
+                sb.append(string);
+            }                
+        }
+        
+        return sb.toString();
+        
+    }
+
     public static Integer indexOf(final Object target, final String fragment) {
         
         Validate.notNull(target, "Cannot apply indexOf on null");


### PR DESCRIPTION
I've added three new methods related to #strings:
- `concat` -> allows the concatenation of  `strings` giving also a value to write in place of null values
  - `equals`
  - `equalsignorecase`
