### PR TITLE
Fix character encoding in .properties

### DIFF
--- a/src/main/java/org/thymeleaf/util/MessageResolutionUtils.java
+++ b/src/main/java/org/thymeleaf/util/MessageResolutionUtils.java
@@ -20,6 +20,7 @@
 package org.thymeleaf.util;
 
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -281,7 +282,8 @@ public final class MessageResolutionUtils {
         }
         final Properties properties = new Properties();
         try {
-            properties.load(propertiesIS);
+            InputStreamReader propertiesReader = new InputStreamReader(propertiesIS);
+            properties.load(propertiesReader);
         } catch (final Exception e) {
             throw new TemplateInputException("Exception loading messages file", e);
         } finally {

--- a/src/main/java/org/thymeleaf/util/MessageResolutionUtils.java
+++ b/src/main/java/org/thymeleaf/util/MessageResolutionUtils.java
@@ -281,14 +281,15 @@ public final class MessageResolutionUtils {
             return null;
         }
         final Properties properties = new Properties();
+        final InputStreamReader propertiesReader = new InputStreamReader(propertiesIS);
         try {
-            InputStreamReader propertiesReader = new InputStreamReader(propertiesIS);
             properties.load(propertiesReader);
         } catch (final Exception e) {
             throw new TemplateInputException("Exception loading messages file", e);
         } finally {
             try {
-                propertiesIS.close();
+            	//InputStream propertiesIS is closed by the Reader
+                propertiesReader.close();
             } catch (Exception e) {
                 throw new TemplateInputException("Exception loading messages file", e);
             }


### PR DESCRIPTION
Hi,

java.util.Properties#load(InputStream inStream)  assumes a character encoding of ISO 8859-1, whereas java.util.Properties#load(Reader reader) - or more specifically InputStreamReader(InputStream in) - uses the default encoding.

This simple patch makes Thymeleaf load .properties files in the default encoding, which can also be set by specifying ie. -Dfile.encoding=UTF-8

As stated above, Thymeleaf currently requires you to save your properties files in ISO 8859-1, which is really annoying if you use UTF-8 everywhere else, as it leaves you with a project with mixed file encodings and can also potentially be screwed up Mavens properties filtering.

I am aware, that this might break existing projects, but the current state is - IMHO - not really acceptable either.

Many thanks
Philipp
