### PR TITLE
Adding OSGi manifest headers to thymeleaf core.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
 
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
+        <version>2.3.2</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,40 @@
         <version>2.1</version>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.4.0</version>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+         <instructions>
+           <Import-Package>
+               javax.servlet.*;version="[2.5,4)";resolution:=optional,
+               javassist.*;version="[3.16.1.GA,4)";resolution:=optional,
+               ognl.*;version="[3.0.6,4)";resolution:=optional,
+               *
+           </Import-Package>
+         </instructions>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
 
     </plugins>
     


### PR DESCRIPTION
As much as I see, there has been an issue since two years about this topic:

https://github.com/thymeleaf/thymeleaf/issues/32

I would like to ask you to add the changes to the pom.xml of thymeleaf!
We tested it and used it within Equinox and it worked for us. Some notes:

We used MVEL2 instead of OGNL. MVEL2 has a nice jar that also contains
OSGi MANIFEST entries. As MVEL2 could have been used pretty easily
(if we do not care that there are some syntax changes in the expressions), 
I made the OGNL and javassist packages optional in the MANIFEST.

We do not use Spring at all. Spring was designed to simplify the Java EE world
and it does a great job. However, the philosophy of Spring does not fit into the
OSGi KISS concept. Spring itself does not support OSGi anymore (although
OSGi is more widely supported from year to year). I think it is not important to handle
thymeleaf-core and thymeleaf-spring jars together concerning to OSGi.
As a first (and probably only one) step, it is enough to put OSGi MANIFEST
entries only into the thymeleaf-core.
