### PR TITLE
Update javassist to 3.18.1-GA for java 8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.16.1-GA</version>
+      <version>3.18.1-GA</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
When using latest thymeleaf 2.1.12.RELEASE/2.1.13-SNAPSHOT with java 8 I ran into the issue described in http://qkyrie.silvrback.com/spring-thymeleaf-and-java-8 .

This PR updates javassist to support java 8. Please be advised there might be an issue with the new version being compiled for java 1.6 where the old one was for 1.5 and thymeleaf being compiled for 1.5. In that case I would also propose to raise the source level of thymeleaf to at least 1.6 as both 1.5 and 1.6 are officially EOL.
