### PR TITLE
Ignore possibility for Javascript serialization

### DIFF
--- a/src/main/java/org/thymeleaf/util/JavaScriptUtils.java
+++ b/src/main/java/org/thymeleaf/util/JavaScriptUtils.java
@@ -356,10 +356,22 @@ public final class JavaScriptUtils {
             for (final PropertyDescriptor descriptor : descriptors) {
                 final Method readMethod =  descriptor.getReadMethod();
                 if (readMethod != null) {
-                    final String name = descriptor.getName();
-                    if (!"class".equals(name.toLowerCase())) {
-                        final Object value = readMethod.invoke(object);
-                        properties.put(name, value);
+                    boolean ignore = false;
+
+                    if (object.getClass().isAnnotationPresent(IgnoreSerialization.class)) {
+                        for (Annotation annotation : readMethod.getDeclaredAnnotations()) {
+                            if (annotation.annotationType() == IgnoreSerialization.class) {
+                                ignore = true;
+                            }
+                        }
+                    }
+
+                    if (!ignore) {
+                        final String name = descriptor.getName();
+                        if (!"class".equals(name.toLowerCase())) {
+                            final Object value = readMethod.invoke(object);
+                            properties.put(name, value);
+                        }
                     }
                 }
             }
@@ -400,5 +412,10 @@ public final class JavaScriptUtils {
     }
 
 
-
+    /**
+     * Value to determine whether to ignore serialization of the given object.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD})
+    public @interface IgnoreSerialization { }
 }

--- a/src/main/java/org/thymeleaf/util/JavaScriptUtils.java
+++ b/src/main/java/org/thymeleaf/util/JavaScriptUtils.java
@@ -358,11 +358,9 @@ public final class JavaScriptUtils {
                 if (readMethod != null) {
                     boolean ignore = false;
 
-                    if (object.getClass().isAnnotationPresent(IgnoreSerialization.class)) {
-                        for (Annotation annotation : readMethod.getDeclaredAnnotations()) {
-                            if (annotation.annotationType() == IgnoreSerialization.class) {
-                                ignore = true;
-                            }
+                    for (Annotation annotation : readMethod.getDeclaredAnnotations()) {
+                        if (annotation.annotationType() == IgnoreSerialization.class) {
+                            ignore = true;
                         }
                     }
 


### PR DESCRIPTION
Added an annotation that could be used to tag elements (fields and methods) which should be ignored when serializing them to Javascript. This can be espacially useful for easy performance enhancements or when lazy loading objects with circulair references, which aren't necessary. In my case lazy loading objects sometimes caused the Javascript serializer to try and serialize 'everything' in memory, which caused a lock up.

I've currently not added a test or test-cases and thus am not sure if these proposed changes are 100% correct. These should probably be tested, but this should be an easy extra and start.

Edit: Additional commit with working changes. 
