### PR TITLE
Wrapping variables map

### DIFF
--- a/src/main/java/org/thymeleaf/context/AbstractProcessingContext.java
+++ b/src/main/java/org/thymeleaf/context/AbstractProcessingContext.java
@@ -95,7 +95,7 @@ public abstract class AbstractProcessingContext implements IProcessingContext {
         // because we want to avoid undesirable interactions like, for example, those that could happen
         // if we executed putAll on a WebVariablesMap object (which would add those variables to the HttpServletRequest
         // and therefore make them available to the whole page and not just the local variable scope).
-        final VariablesMap<String,Object> newEvaluationRoot = new VariablesMap<String, Object>(contextVariables);
+        final VariablesMap<String,Object> newEvaluationRoot = new WrappingVariablesMap<String, Object>(contextVariables);
         if (this.localVariables != null) {
             newEvaluationRoot.putAll(this.localVariables);
         }

--- a/src/main/java/org/thymeleaf/context/WebVariablesMap.java
+++ b/src/main/java/org/thymeleaf/context/WebVariablesMap.java
@@ -22,9 +22,8 @@ package org.thymeleaf.context;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -260,7 +259,7 @@ class WebVariablesMap extends VariablesMap<String,Object> {
     @Override
     @SuppressWarnings("unchecked")
     public Set<String> keySet() {
-        final Set<String> keySet = new LinkedHashSet<String>(10);
+        final Set<String> keySet = new HashSet<String>(attributeNames.size() + 3);
         keySet.addAll(this.attributeNames);
         keySet.addAll(super.keySet());
         return keySet;
@@ -271,7 +270,7 @@ class WebVariablesMap extends VariablesMap<String,Object> {
     @Override
     @SuppressWarnings("unchecked")
     public Collection<Object> values() {
-        final List<Object> values = new ArrayList<Object>(10);
+        final List<Object> values = new ArrayList<Object>(this.attributeNames.size() + 3);
         for (String attributeName : attributeNames) {
             values.add(this.request.getAttribute(attributeName));
         }
@@ -283,7 +282,7 @@ class WebVariablesMap extends VariablesMap<String,Object> {
 
     @Override
     public Set<java.util.Map.Entry<String,Object>> entrySet() {
-        final Map<String, Object> attributeMap = new LinkedHashMap<String, Object>(10);
+        final Map<String, Object> attributeMap = new HashMap<String, Object>(this.attributeNames.size() + 3);
         for (String attributeName : attributeNames) {
             attributeMap.put(attributeName, request.getAttribute(attributeName));
         }
@@ -355,7 +354,7 @@ class WebVariablesMap extends VariablesMap<String,Object> {
     @SuppressWarnings("unchecked")
     private static Map<String,Object> getAttributeMap(final HttpServletRequest request) {
 
-        final Map<String,Object> attributeMap = new LinkedHashMap<String, Object>(10);
+        final Map<String,Object> attributeMap = new HashMap<String, Object>();
         final Enumeration<String> attributeNames = request.getAttributeNames();
         while (attributeNames.hasMoreElements()) {
             final String attributeName = attributeNames.nextElement();

--- a/src/main/java/org/thymeleaf/context/WebVariablesMap.java
+++ b/src/main/java/org/thymeleaf/context/WebVariablesMap.java
@@ -22,6 +22,7 @@ package org.thymeleaf.context;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -37,9 +38,9 @@ import javax.servlet.http.HttpServletRequest;
  *   and {@link #put(Object, Object)} calls to a contained 
  *   HttpServletRequest. 
  * </p>
- * 
+ *
  * @author Daniel Fern&aacute;ndez
- * 
+ *
  * @since 2.0.9
  *
  */
@@ -48,8 +49,8 @@ class WebVariablesMap extends VariablesMap<String,Object> {
 
     private static final long serialVersionUID = 3862067921983550180L;
 
-    
-    
+
+
     /**
      * <p>
      *   Name of the variable that contains the request parameters.
@@ -80,18 +81,19 @@ class WebVariablesMap extends VariablesMap<String,Object> {
      * DIRECTLY AT THE EXTENDED HASHMAP.
      * ---------------------------------------------------------------------------
      */
-    
-    
+
+
     private final HttpServletRequest request;
     private final ServletContext servletContext;
 
-    
+
     private final WebRequestParamsVariablesMap requestParamsVariablesMap;
     private final WebSessionVariablesMap sessionVariablesMap;
     private final WebServletContextVariablesMap servletContextVariablesMap;
-    
-    
-    
+
+    private final Set<String> attributeNames = new HashSet<String>();
+
+
 
 
     WebVariablesMap(final HttpServletRequest request, final ServletContext servletContext,
@@ -110,6 +112,12 @@ class WebVariablesMap extends VariablesMap<String,Object> {
         super.put(PARAM_VARIABLE_NAME, this.requestParamsVariablesMap);
         super.put(SESSION_VARIABLE_NAME, this.sessionVariablesMap);
 
+        // cache the attribute names, as they're expensive to get from the request 1000s of times per request
+        Enumeration<String> names = request.getAttributeNames();
+        while (names.hasMoreElements()) {
+            this.attributeNames.add(names.nextElement());
+        }
+
         if (m != null) {
             // This must be done at the end because it relies on the request having been already set.
             putAll(m);
@@ -119,7 +127,7 @@ class WebVariablesMap extends VariablesMap<String,Object> {
 
 
 
-    
+
     public WebRequestParamsVariablesMap getRequestParamsVariablesMap() {
         return this.requestParamsVariablesMap;
     }
@@ -138,28 +146,22 @@ class WebVariablesMap extends VariablesMap<String,Object> {
 
 
 
-    
+
     @Override
     @SuppressWarnings("unchecked")
     public int size() {
-        int size = 3; // session, param, application
-        final Enumeration<String> attributeNames = this.request.getAttributeNames();
-        while (attributeNames.hasMoreElements()) {
-            attributeNames.nextElement();
-            size++;
-        }
-        return size;
+        return attributeNames.size() + 3; // session, param, application
     }
 
-    
-    
+
+
     @Override
     public boolean isEmpty() {
         return false; // at least 3 elements (session, param, application)
     }
 
-    
-    
+
+
     @Override
     public Object get(final Object key) {
         if (isReservedVariableName((String)key)) {
@@ -168,32 +170,19 @@ class WebVariablesMap extends VariablesMap<String,Object> {
         return this.request.getAttribute((String)key);
     }
 
-    
-    
+
+
     @Override
     @SuppressWarnings("unchecked")
     public boolean containsKey(final Object key) {
         if (isReservedVariableName((String)key)) {
             return true;
         }
-        final Enumeration<String> attributeNames = this.request.getAttributeNames();
-        while (attributeNames.hasMoreElements()) {
-            final String attributeName = attributeNames.nextElement(); 
-            if (key == null) {
-                if (attributeName == null) {
-                    return true;
-                }
-            } else {
-                if (key.equals(attributeName)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return attributeNames.contains(key);
     }
 
-    
-    
+
+
     @Override
     public Object put(final String key, final Object value) {
         if (isReservedVariableName(key)) {
@@ -202,11 +191,12 @@ class WebVariablesMap extends VariablesMap<String,Object> {
                     "a reserved variable name.");
         }
         this.request.setAttribute(key, value);
+        this.attributeNames.add(key);
         return value;
     }
 
-    
-    
+
+
     @Override
     public void putAll(final Map<? extends String, ?> m) {
         for (final Map.Entry<? extends String, ?> mEntry : m.entrySet()) {
@@ -214,8 +204,8 @@ class WebVariablesMap extends VariablesMap<String,Object> {
         }
     }
 
-    
-    
+
+
     @Override
     public Object remove(final Object key) {
         if (isReservedVariableName((String)key)) {
@@ -225,19 +215,20 @@ class WebVariablesMap extends VariablesMap<String,Object> {
         }
         final Object value = this.request.getAttribute((String)key);
         this.request.removeAttribute((String)key);
+        this.attributeNames.remove(key);
         return value;
     }
 
-    
-    
+
+
     @Override
     public void clear() {
         throw new UnsupportedOperationException(
                 "Web variable context map cannot be completely cleared.");
     }
 
-    
-    
+
+
     @Override
     @SuppressWarnings("unchecked")
     public boolean containsValue(final Object value) {
@@ -249,9 +240,7 @@ class WebVariablesMap extends VariablesMap<String,Object> {
                 return true;
             }
         }
-        final Enumeration<String> attributeNames = this.request.getAttributeNames();
-        while (attributeNames.hasMoreElements()) {
-            final String attributeName = attributeNames.nextElement();
+        for (String attributeName : attributeNames) {
             final Object attributeValue = this.request.getAttribute(attributeName);
             if (value == null) {
                 if (attributeValue == null) {
@@ -267,47 +256,45 @@ class WebVariablesMap extends VariablesMap<String,Object> {
     }
 
 
-    
+
     @Override
     @SuppressWarnings("unchecked")
     public Set<String> keySet() {
         final Set<String> keySet = new LinkedHashSet<String>(10);
-        final Enumeration<String> attributeNames = this.request.getAttributeNames();
-        while (attributeNames.hasMoreElements()) {
-            keySet.add(attributeNames.nextElement());
-        }
+        keySet.addAll(this.attributeNames);
         keySet.addAll(super.keySet());
         return keySet;
     }
 
-    
-    
+
+
     @Override
     @SuppressWarnings("unchecked")
     public Collection<Object> values() {
         final List<Object> values = new ArrayList<Object>(10);
-        final Enumeration<String> attributeNames = this.request.getAttributeNames();
-        while (attributeNames.hasMoreElements()) {
-            final String attributeName = attributeNames.nextElement();
+        for (String attributeName : attributeNames) {
             values.add(this.request.getAttribute(attributeName));
         }
         values.addAll(super.values());
         return values;
     }
 
-    
-    
+
+
     @Override
     public Set<java.util.Map.Entry<String,Object>> entrySet() {
-        final Map<String,Object> attributeMap = getAttributeMap(this.request);
-        for (final Map.Entry<String,Object> superEntry : super.entrySet()) {
+        final Map<String, Object> attributeMap = new LinkedHashMap<String, Object>(10);
+        for (String attributeName : attributeNames) {
+            attributeMap.put(attributeName, request.getAttribute(attributeName));
+        }
+        for (final Map.Entry<String, Object> superEntry : super.entrySet()) {
             attributeMap.put(superEntry.getKey(), superEntry.getValue());
         }
         return attributeMap.entrySet();
     }
 
-    
-    
+
+
     @Override
     public String toString() {
         final Map<String,Object> attributeMap = getAttributeMap(this.request);
@@ -317,12 +304,12 @@ class WebVariablesMap extends VariablesMap<String,Object> {
         return attributeMap.toString();
     }
 
-    
 
-    
-    
-    
-    
+
+
+
+
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -367,7 +354,7 @@ class WebVariablesMap extends VariablesMap<String,Object> {
 
     @SuppressWarnings("unchecked")
     private static Map<String,Object> getAttributeMap(final HttpServletRequest request) {
-        
+
         final Map<String,Object> attributeMap = new LinkedHashMap<String, Object>(10);
         final Enumeration<String> attributeNames = request.getAttributeNames();
         while (attributeNames.hasMoreElements()) {
@@ -375,15 +362,15 @@ class WebVariablesMap extends VariablesMap<String,Object> {
             final Object attributeValue = request.getAttribute(attributeName);
             attributeMap.put(attributeName, attributeValue);
         }
-        
+
         return attributeMap;
-        
+
     }
 
-    
-    
 
-    
+
+
+
     private static boolean isReservedVariableName(final String name) {
         return PARAM_VARIABLE_NAME.equals(name) ||
                SESSION_VARIABLE_NAME.equals(name) ||

--- a/src/main/java/org/thymeleaf/context/WrappingVariablesMap.java
+++ b/src/main/java/org/thymeleaf/context/WrappingVariablesMap.java
@@ -1,0 +1,124 @@
+package org.thymeleaf.context;
+
+import java.util.*;
+
+/**
+ * Wrapper around a {@link VariablesMap} which 'masks' the wrapped map by keeping track of extra puts.
+ * Does not support removing entries from the wrapped map through {@see #remove} nor providing true views on the 
+ * underlying map through {@see #keySet}, {@see #values} and {@see entrySet} unless the wrapped map is empty. 
+ * This is more efficient than making defensive copies up-front for every node.
+ */
+public class WrappingVariablesMap<K,V> extends VariablesMap<K, V> {
+
+    private VariablesMap<K, V> targetMap;
+
+    public WrappingVariablesMap(VariablesMap<K, V> targetMap) {
+        this.targetMap = targetMap;
+    }
+
+    @Override
+    public int size() {
+        return super.size() + targetMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty() && targetMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        if (super.containsKey(key)) {
+            return true;
+        }
+        return targetMap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        if (super.containsValue(value)) {
+            return true;
+        }
+        return targetMap.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        if (super.containsKey(key)) {
+            return super.get(key);
+        }
+        return targetMap.get(key);
+    }
+
+    @Override
+    public V remove(Object key) {
+        if (super.containsKey(key)) {
+            return super.remove(key);
+        }
+        if (targetMap.containsKey(key)) {
+            throw new UnsupportedOperationException("Can't remove key from wrapped map in WrappingVariablesMap");
+        }
+        return null;
+    }
+
+    @Override
+    public void clear() {
+        this.targetMap = new VariablesMap<K, V>(0);
+        super.clear();
+    }
+
+    /**
+     * This violates the Map contract because it returns a read-only Set, not a mutable Set
+     * that reflects the underlying table, unless the wrapped map's key set is empty.
+     *
+     * @return immutable set containing the union of the wrapped map's keys and this map's keys,
+     *         or the real key set of this map if the wrapped map is empty.
+     */
+    @Override
+    public Set<K> keySet() {
+        Set<K> targetKeySet = this.targetMap.keySet();
+        if (targetKeySet.isEmpty()) {
+            return super.keySet();
+        }
+        Set<K> keySet = new HashSet<K>(targetKeySet);
+        keySet.addAll(super.keySet());
+        return Collections.unmodifiableSet(keySet);
+    }
+
+    /**
+     * This violates the Map contract because it returns a read-only collection, not a mutable one
+     * that reflects the underlying table, unless the wrapped map's values collection is empty.
+     *
+     * @return immutable collection containing the union of the wrapped map's values and this map's values,
+     *         or the real values collection of this map if the wrapped map is empty.
+     */
+    @Override
+    public Collection<V> values() {
+        Collection<V> targetValues = this.targetMap.values();
+        if (targetValues.isEmpty()) {
+            return super.values();
+        }
+        Collection<V> values = new ArrayList<V>(targetValues);
+        values.addAll(super.values());
+        return Collections.unmodifiableCollection(values);
+    }
+
+    /**
+     * This violates the Map contract because it returns a read-only Set, not a mutable Sne
+     * that reflects the underlying table, unless the wrapped map is empty.
+     *
+     * @return immutable Set containing the union of the wrapped map's entrySet and this map's entrySet,
+     *         or the real entry set of this map if the wrapped map is empty
+     */
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        Set<Map.Entry<K, V>> targetEntrySet = targetMap.entrySet();
+        if (targetEntrySet.isEmpty()) {
+            return super.entrySet();
+        }
+        Set<Map.Entry<K, V>> entrySet = new HashSet<Map.Entry<K, V>>(targetEntrySet);
+        entrySet.addAll(super.entrySet());
+        return Collections.unmodifiableSet(entrySet);
+    }
+
+}


### PR DESCRIPTION
Here's another optimization (in addition to the one in https://github.com/thymeleaf/thymeleaf/pull/318), which gets rid of the constant copying of the attributes in a WebVariablesMap for every node resulting in many expensive calls to WebVariablesMap#entrySet. I've introduced a WrappingVariablesMap, which basically masks a given VariablesMap which stays read-only and allows adding contents without the need to copy the whole original map. 
It's not strictly conformant with respect to the java.util.Map contract, but neither is the WebVariablesMap. At least I've documented the deviations ;)

In my local testing this patch saves about 200 milliseconds for one view render action by preventing almost 2000 full copies of a WebVariablesContext's contents from being made. In my Spring app the requests contain about a hundred request attributes when rendering the view, while the added contents typically seems limited to a handful of additional entries, so only keeping track of those handful is much more efficient, both in terms of CPU and memory being used.
Note that I have assumed here that the Thymeleaf code doesn't rely on VariablesMap.keySet(), .values() and .entrySet returning a mutable collection supporting directly modifying the underlying map. I feel pretty confident about that assumption given the way that WebVariablesMap works, but please check this for correctness.

I also made some small changes to my earlier proposal of caching attribute names in WebVariablesMap: you don't need ordered collections there and can do some smarter sizing when creating the collections.
