### PR TITLE
WrappingVariablesMap

### DIFF
--- a/src/main/java/org/thymeleaf/context/AbstractProcessingContext.java
+++ b/src/main/java/org/thymeleaf/context/AbstractProcessingContext.java
@@ -95,7 +95,7 @@ public abstract class AbstractProcessingContext implements IProcessingContext {
         // because we want to avoid undesirable interactions like, for example, those that could happen
         // if we executed putAll on a WebVariablesMap object (which would add those variables to the HttpServletRequest
         // and therefore make them available to the whole page and not just the local variable scope).
-        final VariablesMap<String,Object> newEvaluationRoot = new VariablesMap<String, Object>(contextVariables);
+        final VariablesMap<String,Object> newEvaluationRoot = new WrappingVariablesMap<String, Object>(contextVariables);
         if (this.localVariables != null) {
             newEvaluationRoot.putAll(this.localVariables);
         }

--- a/src/main/java/org/thymeleaf/context/WrappingVariablesMap.java
+++ b/src/main/java/org/thymeleaf/context/WrappingVariablesMap.java
@@ -1,0 +1,124 @@
+package org.thymeleaf.context;
+
+import java.util.*;
+
+/**
+ * Wrapper around a {@link VariablesMap} which 'masks' the wrapped map by keeping track of extra puts.
+ * Does not support removing entries from the wrapped map through {@see #remove} nor providing true views on the 
+ * underlying map through {@see #keySet}, {@see #values} and {@see entrySet} unless the wrapped map is empty. 
+ * This is more efficient than making defensive copies up-front for every node.
+ */
+public class WrappingVariablesMap<K,V> extends VariablesMap<K, V> {
+
+    private VariablesMap<K, V> targetMap;
+
+    public WrappingVariablesMap(VariablesMap<K, V> targetMap) {
+        this.targetMap = targetMap;
+    }
+
+    @Override
+    public int size() {
+        return super.size() + targetMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty() && targetMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        if (super.containsKey(key)) {
+            return true;
+        }
+        return targetMap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        if (super.containsValue(value)) {
+            return true;
+        }
+        return targetMap.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        if (super.containsKey(key)) {
+            return super.get(key);
+        }
+        return targetMap.get(key);
+    }
+
+    @Override
+    public V remove(Object key) {
+        if (super.containsKey(key)) {
+            return super.remove(key);
+        }
+        if (targetMap.containsKey(key)) {
+            throw new UnsupportedOperationException("Can't remove key from wrapped map in WrappingVariablesMap");
+        }
+        return null;
+    }
+
+    @Override
+    public void clear() {
+        this.targetMap = new VariablesMap<K, V>(0);
+        super.clear();
+    }
+
+    /**
+     * This violates the Map contract because it returns a read-only Set, not a mutable Set
+     * that reflects the underlying table, unless the wrapped map's key set is empty.
+     *
+     * @return immutable set containing the union of the wrapped map's keys and this map's keys,
+     *         or the real key set of this map if the wrapped map is empty.
+     */
+    @Override
+    public Set<K> keySet() {
+        Set<K> targetKeySet = this.targetMap.keySet();
+        if (targetKeySet.isEmpty()) {
+            return super.keySet();
+        }
+        Set<K> keySet = new HashSet<K>(targetKeySet);
+        keySet.addAll(super.keySet());
+        return Collections.unmodifiableSet(keySet);
+    }
+
+    /**
+     * This violates the Map contract because it returns a read-only collection, not a mutable one
+     * that reflects the underlying table, unless the wrapped map's values collection is empty.
+     *
+     * @return immutable collection containing the union of the wrapped map's values and this map's values,
+     *         or the real values collection of this map if the wrapped map is empty.
+     */
+    @Override
+    public Collection<V> values() {
+        Collection<V> targetValues = this.targetMap.values();
+        if (targetValues.isEmpty()) {
+            return super.values();
+        }
+        Collection<V> values = new ArrayList<V>(targetValues);
+        values.addAll(super.values());
+        return Collections.unmodifiableCollection(values);
+    }
+
+    /**
+     * This violates the Map contract because it returns a read-only Set, not a mutable Sne
+     * that reflects the underlying table, unless the wrapped map is empty.
+     *
+     * @return immutable Set containing the union of the wrapped map's entrySet and this map's entrySet,
+     *         or the real entry set of this map if the wrapped map is empty
+     */
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        Set<Map.Entry<K, V>> targetEntrySet = targetMap.entrySet();
+        if (targetEntrySet.isEmpty()) {
+            return super.entrySet();
+        }
+        Set<Map.Entry<K, V>> entrySet = new HashSet<Map.Entry<K, V>>(targetEntrySet);
+        entrySet.addAll(super.entrySet());
+        return Collections.unmodifiableSet(entrySet);
+    }
+
+}

--- a/src/main/java/org/thymeleaf/context/WrappingVariablesMap.java
+++ b/src/main/java/org/thymeleaf/context/WrappingVariablesMap.java
@@ -4,8 +4,8 @@ import java.util.*;
 
 /**
  * Wrapper around a {@link VariablesMap} which 'masks' the wrapped map by keeping track of extra puts.
- * Does not support removing entries from the wrapped map through {@see #remove} nor providing true views on the 
- * underlying map through {@see #keySet}, {@see #values} and {@see entrySet} unless the wrapped map is empty. 
+ * Does not support removing entries from the wrapped map through {@link #remove(Object)} nor providing true views on the
+ * underlying map through {@link #keySet()}, {@link #values()} and {@link #entrySet()} unless the wrapped map is empty.
  * This is more efficient than making defensive copies up-front for every node.
  */
 public class WrappingVariablesMap<K,V> extends VariablesMap<K, V> {


### PR DESCRIPTION
Here's another optimization (in addition to the one in #318, but completely independent), which gets rid of the constant copying of the attributes in a WebVariablesMap for every node resulting in many expensive calls to WebVariablesMap#entrySet from inside createEvaluationRoot(). I've introduced a WrappingVariablesMap, which basically masks a given VariablesMap which stays read-only and allows adding contents without the need to copy the whole original map.
It's not strictly conformant with respect to the java.util.Map contract, but neither is the WebVariablesMap. At least I've documented the deviations ;)

In my local testing this patch saves about 200 milliseconds for one view render action by preventing almost 2000 full copies of a WebVariablesContext's contents from being made. This is after applying the fix in #318 first BTW, this should save even more without that patch. 
In my Spring app the requests contain about a hundred request attributes when rendering the view, while the added contents typically seems limited to a handful of additional entries, so only keeping track of those handful is much more efficient, both in terms of CPU and memory being used.
Note that I have assumed here that the Thymeleaf code doesn't rely on VariablesMap.keySet(), .values() and .entrySet() returning a mutable collection supporting directly modifying the underlying map and doesn't need to remove variables from the original mao . I feel pretty confident about that assumption given the way that WebVariablesMap works, but please check this for correctness.
