### PR TITLE
Proposed fix for #328 : Making the absent message formatting configurable

### DIFF
--- a/src/main/java/org/thymeleaf/ConfigurationPrinterHelper.java
+++ b/src/main/java/org/thymeleaf/ConfigurationPrinterHelper.java
@@ -38,7 +38,7 @@ import org.thymeleaf.dialect.IProcessorDialect;
 import org.thymeleaf.engine.ITemplateHandler;
 import org.thymeleaf.expression.ExpressionObjectDefinition;
 import org.thymeleaf.expression.IExpressionObjectFactory;
-import org.thymeleaf.messageresolver.IMessageResolver;
+import org.thymeleaf.message.resolver.IMessageResolver;
 import org.thymeleaf.processor.IProcessor;
 import org.thymeleaf.processor.PrecedenceProcessorComparator;
 import org.thymeleaf.processor.cdatasection.ICDATASectionProcessor;

--- a/src/main/java/org/thymeleaf/EngineConfiguration.java
+++ b/src/main/java/org/thymeleaf/EngineConfiguration.java
@@ -33,7 +33,8 @@ import org.thymeleaf.engine.AttributeDefinitions;
 import org.thymeleaf.engine.ElementDefinitions;
 import org.thymeleaf.engine.ITemplateHandler;
 import org.thymeleaf.expression.IExpressionObjectFactory;
-import org.thymeleaf.messageresolver.IMessageResolver;
+import org.thymeleaf.message.absent.IAbsentMessageFormatter;
+import org.thymeleaf.message.resolver.IMessageResolver;
 import org.thymeleaf.processor.cdatasection.ICDATASectionProcessor;
 import org.thymeleaf.processor.comment.ICommentProcessor;
 import org.thymeleaf.processor.doctype.IDocTypeProcessor;
@@ -60,6 +61,7 @@ public class EngineConfiguration implements IEngineConfiguration {
     private final Set<ITemplateResolver> templateResolvers;
     private final Set<IMessageResolver> messageResolvers;
     private final ICacheManager cacheManager;
+    private final IAbsentMessageFormatter absentMessageFormatter;
 
 
     public EngineConfiguration(
@@ -67,7 +69,8 @@ public class EngineConfiguration implements IEngineConfiguration {
             final Set<IMessageResolver> messageResolvers,
             final Set<DialectConfiguration> dialectConfigurations,
             final ICacheManager cacheManager,
-            final ITextRepository textRepository) {
+            final ITextRepository textRepository,
+            final IAbsentMessageFormatter absentMessageFormatter) {
 
         super();
 
@@ -91,7 +94,7 @@ public class EngineConfiguration implements IEngineConfiguration {
 
         this.dialectSetConfiguration = DialectSetConfiguration.build(dialectConfigurations);
         this.textRepository = textRepository;
-
+        this.absentMessageFormatter = absentMessageFormatter;
     }
 
 
@@ -200,13 +203,9 @@ public class EngineConfiguration implements IEngineConfiguration {
         return this.dialectSetConfiguration.getExpressionObjectFactory();
     }
 
-
-
-
-
-
-
-
+    public IAbsentMessageFormatter getAbsentMessageFormatter() {
+        return absentMessageFormatter;
+    }
 
 
     private static final class TemplateResolverComparator implements Comparator<ITemplateResolver> {

--- a/src/main/java/org/thymeleaf/IEngineConfiguration.java
+++ b/src/main/java/org/thymeleaf/IEngineConfiguration.java
@@ -29,7 +29,8 @@ import org.thymeleaf.engine.AttributeDefinitions;
 import org.thymeleaf.engine.ElementDefinitions;
 import org.thymeleaf.engine.ITemplateHandler;
 import org.thymeleaf.expression.IExpressionObjectFactory;
-import org.thymeleaf.messageresolver.IMessageResolver;
+import org.thymeleaf.message.absent.IAbsentMessageFormatter;
+import org.thymeleaf.message.resolver.IMessageResolver;
 import org.thymeleaf.processor.cdatasection.ICDATASectionProcessor;
 import org.thymeleaf.processor.comment.ICommentProcessor;
 import org.thymeleaf.processor.doctype.IDocTypeProcessor;
@@ -82,5 +83,7 @@ public interface IEngineConfiguration {
     public Map<String,Object> getExecutionAttributes();
 
     public IExpressionObjectFactory getExpressionObjectFactory();
+
+    public IAbsentMessageFormatter getAbsentMessageFormatter();
 
 }

--- a/src/main/java/org/thymeleaf/TemplateEngine.java
+++ b/src/main/java/org/thymeleaf/TemplateEngine.java
@@ -41,8 +41,10 @@ import org.thymeleaf.engine.TemplateManager;
 import org.thymeleaf.exceptions.TemplateEngineException;
 import org.thymeleaf.exceptions.TemplateOutputException;
 import org.thymeleaf.exceptions.TemplateProcessingException;
-import org.thymeleaf.messageresolver.IMessageResolver;
-import org.thymeleaf.messageresolver.StandardMessageResolver;
+import org.thymeleaf.message.absent.IAbsentMessageFormatter;
+import org.thymeleaf.message.absent.StandardAbsentMessageFormatter;
+import org.thymeleaf.message.resolver.IMessageResolver;
+import org.thymeleaf.message.resolver.StandardMessageResolver;
 import org.thymeleaf.standard.StandardDialect;
 import org.thymeleaf.templateresolver.ITemplateResolver;
 import org.thymeleaf.templateresolver.StringTemplateResolver;
@@ -230,6 +232,7 @@ public class TemplateEngine implements ITemplateEngine {
 
     private IEngineConfiguration configuration = null;
     private TemplateManager templateManager = null;
+    private IAbsentMessageFormatter absentMessageFormatter = new StandardAbsentMessageFormatter();
 
 
 
@@ -306,7 +309,7 @@ public class TemplateEngine implements ITemplateEngine {
                     }
 
                     this.configuration =
-                            new EngineConfiguration(this.templateResolvers, this.messageResolvers, this.dialectConfigurations, this.cacheManager, this.textRepository);
+                            new EngineConfiguration(this.templateResolvers, this.messageResolvers, this.dialectConfigurations, this.cacheManager, this.textRepository, this.absentMessageFormatter);
                     this.templateManager = new TemplateManager(this.configuration);
 
                     initializeSpecific();
@@ -783,12 +786,20 @@ public class TemplateEngine implements ITemplateEngine {
         this.messageResolvers.add(messageResolver);
     }
 
-    
-    
-    
 
-    
-    
+    /**
+     * <p>
+     *     Sets the absent message formatter for this template engine,
+     *     instead of using the default StandardAbsentMessageFormatter.
+     * </p>
+     * @param absentMessageFormatter the absent message formatter to be set.
+     */
+    public void setAbsentMessageFormatter(final IAbsentMessageFormatter absentMessageFormatter) {
+        Validate.notNull(absentMessageFormatter, "Absent Message Formatter cannot be null");
+        this.absentMessageFormatter = absentMessageFormatter;
+    }
+
+
     /**
      * <p>
      *   Completely clears the Template Cache.

--- a/src/main/java/org/thymeleaf/message/absent/IAbsentMessageFormatter.java
+++ b/src/main/java/org/thymeleaf/message/absent/IAbsentMessageFormatter.java
@@ -1,58 +1,33 @@
 /*
  * =============================================================================
- * 
+ *
  *   Copyright (c) 2011-2014, The THYMELEAF team (http://www.thymeleaf.org)
- * 
+ *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- * 
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
- * 
+ *
  * =============================================================================
  */
-package org.thymeleaf.messageresolver;
+package org.thymeleaf.message.absent;
 
-import org.thymeleaf.util.Validate;
-
+import java.util.Locale;
 
 /**
- * <p>
- *   Result of resolving a message.
- * </p>
- * 
- * @author Daniel Fern&aacute;ndez
- * 
- * @since 1.0
+ * Provides the representation of a message that could not be resolved.
  *
+ * @author Mathieu Agar <mathieu.agar@gmail.com>
  */
-public final class MessageResolution {
+public interface IAbsentMessageFormatter {
 
-    private final String resolvedMessage;
-    
-    
-    public MessageResolution(final String resolvedMessage) {
-        super();
-        Validate.notNull(resolvedMessage, "Resolved message cannot be null");
-        this.resolvedMessage = resolvedMessage;
-    }
-    
-    
-    /**
-     * <p>
-     *  Returns the resolved message (as String).
-     * </p>
-     * 
-     * @return the resolved message.
-     */
-    public String getResolvedMessage() {
-        return this.resolvedMessage;
-    }
-    
+    String getAbsentMessageRepresentation(final String messageKey, final Locale locale);
+
 }

--- a/src/main/java/org/thymeleaf/message/absent/StandardAbsentMessageFormatter.java
+++ b/src/main/java/org/thymeleaf/message/absent/StandardAbsentMessageFormatter.java
@@ -1,0 +1,39 @@
+/*
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2014, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * =============================================================================
+ */
+package org.thymeleaf.message.absent;
+
+import org.thymeleaf.util.Validate;
+
+import java.util.Locale;
+
+public class StandardAbsentMessageFormatter implements IAbsentMessageFormatter {
+
+    public StandardAbsentMessageFormatter() {
+        super();
+    }
+
+    public String getAbsentMessageRepresentation(final String messageKey, final Locale locale) {
+        Validate.notNull(messageKey, "Message key cannot be null");
+        if (locale != null) {
+            return "??"+messageKey+"_" + locale.toString() + "??";
+        }
+        return "??"+messageKey+"_" + "??";
+    }
+}

--- a/src/main/java/org/thymeleaf/message/resolver/AbstractMessageResolver.java
+++ b/src/main/java/org/thymeleaf/message/resolver/AbstractMessageResolver.java
@@ -17,7 +17,7 @@
  * 
  * =============================================================================
  */
-package org.thymeleaf.messageresolver;
+package org.thymeleaf.message.resolver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/thymeleaf/message/resolver/IMessageResolver.java
+++ b/src/main/java/org/thymeleaf/message/resolver/IMessageResolver.java
@@ -17,7 +17,7 @@
  * 
  * =============================================================================
  */
-package org.thymeleaf.messageresolver;
+package org.thymeleaf.message.resolver;
 
 import org.thymeleaf.context.ITemplateProcessingContext;
 

--- a/src/main/java/org/thymeleaf/message/resolver/MessageResolution.java
+++ b/src/main/java/org/thymeleaf/message/resolver/MessageResolution.java
@@ -1,0 +1,58 @@
+/*
+ * =============================================================================
+ * 
+ *   Copyright (c) 2011-2014, The THYMELEAF team (http://www.thymeleaf.org)
+ * 
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ * 
+ * =============================================================================
+ */
+package org.thymeleaf.message.resolver;
+
+import org.thymeleaf.util.Validate;
+
+
+/**
+ * <p>
+ *   Result of resolving a message.
+ * </p>
+ * 
+ * @author Daniel Fern&aacute;ndez
+ * 
+ * @since 1.0
+ *
+ */
+public final class MessageResolution {
+
+    private final String resolvedMessage;
+    
+    
+    public MessageResolution(final String resolvedMessage) {
+        super();
+        Validate.notNull(resolvedMessage, "Resolved message cannot be null");
+        this.resolvedMessage = resolvedMessage;
+    }
+    
+    
+    /**
+     * <p>
+     *  Returns the resolved message (as String).
+     * </p>
+     * 
+     * @return the resolved message.
+     */
+    public String getResolvedMessage() {
+        return this.resolvedMessage;
+    }
+    
+}

--- a/src/main/java/org/thymeleaf/message/resolver/StandardMessageResolver.java
+++ b/src/main/java/org/thymeleaf/message/resolver/StandardMessageResolver.java
@@ -17,7 +17,7 @@
  * 
  * =============================================================================
  */
-package org.thymeleaf.messageresolver;
+package org.thymeleaf.message.resolver;
 
 import java.util.Properties;
 

--- a/src/main/java/org/thymeleaf/processor/AbstractProcessor.java
+++ b/src/main/java/org/thymeleaf/processor/AbstractProcessor.java
@@ -20,6 +20,7 @@
 package org.thymeleaf.processor;
 
 import org.thymeleaf.context.ITemplateProcessingContext;
+import org.thymeleaf.message.resolver.IMessageResolver;
 import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.util.MessageResolutionUtils;
 import org.thymeleaf.util.Validate;
@@ -89,19 +90,10 @@ public abstract class AbstractProcessor implements IProcessor {
             return templateMessage;
         }
 
-        final String processorMessage =
-                MessageResolutionUtils.resolveMessageForClass(
-                        processingContext.getConfiguration(), this.getClass(),
-                        processingContext.getLocale(), messageKey,
-                        messageParameters, false);
-
-        if (processorMessage != null) {
-            return processorMessage;
-        }
-
-        return MessageResolutionUtils.getAbsentMessageRepresentation(
-                messageKey, processingContext.getLocale());
-
+        return MessageResolutionUtils.resolveMessageForClass(
+                processingContext.getConfiguration(), this.getClass(),
+                processingContext.getLocale(), messageKey,
+                messageParameters, true);
     }
 
 
@@ -112,7 +104,7 @@ public abstract class AbstractProcessor implements IProcessor {
      * </p>
      * <p>
      *   <i>Template messages</i> are resolved by the <i>Message Resolver</i>
-     *   ({@link org.thymeleaf.messageresolver.IMessageResolver}) instances
+     *   ({@link IMessageResolver}) instances
      *   configured at the Template Engine (executed in chain) in exactly the same way as,
      *   for example, a <tt>#{...}</tt> expression would when using the <i>Standard
      *   Dialect</i> or the <i>SpringStandard Dialect</i>.

--- a/src/main/java/org/thymeleaf/util/MessageResolutionUtils.java
+++ b/src/main/java/org/thymeleaf/util/MessageResolutionUtils.java
@@ -39,8 +39,9 @@ import org.thymeleaf.context.IContext;
 import org.thymeleaf.context.ITemplateProcessingContext;
 import org.thymeleaf.exceptions.TemplateInputException;
 import org.thymeleaf.exceptions.TemplateProcessingException;
-import org.thymeleaf.messageresolver.IMessageResolver;
-import org.thymeleaf.messageresolver.MessageResolution;
+import org.thymeleaf.message.absent.IAbsentMessageFormatter;
+import org.thymeleaf.message.resolver.IMessageResolver;
+import org.thymeleaf.message.resolver.MessageResolution;
 import org.thymeleaf.resource.IResource;
 import org.thymeleaf.resourceresolver.ClassLoaderResourceResolver;
 import org.thymeleaf.resourceresolver.IResourceResolver;
@@ -92,12 +93,12 @@ public final class MessageResolutionUtils {
         }
         
         if (messageResolution == null) {
-            
             if (!returnStringAlways) {
                 return null;
             }
-            
-            return getAbsentMessageRepresentation(messageKey, processingContext.getLocale());
+
+            final IAbsentMessageFormatter absentMessageFormatter = processingContext.getConfiguration().getAbsentMessageFormatter();
+            return absentMessageFormatter.getAbsentMessageRepresentation(messageKey, processingContext.getLocale());
             
         }
         
@@ -165,7 +166,8 @@ public final class MessageResolutionUtils {
         if (messageValue == null) {
 
             if (returnStringAlways) {
-                return getAbsentMessageRepresentation(messageKey, locale);
+                final IAbsentMessageFormatter absentMessageFormatter = configuration.getAbsentMessageFormatter();
+                return absentMessageFormatter.getAbsentMessageRepresentation(messageKey, locale);
             }
 
             return null;
@@ -180,17 +182,7 @@ public final class MessageResolutionUtils {
         return messageFormat.format(messageParameters);
 
     }
-    
-    
-    
-    public static String getAbsentMessageRepresentation(final String messageKey, final Locale locale) {
-        Validate.notNull(messageKey, "Message key cannot be null");
-        if (locale != null) {
-            return "??"+messageKey+"_" + locale.toString() + "??";
-        }
-        return "??"+messageKey+"_" + "??";
-    }
-    
+
     
     
     


### PR DESCRIPTION
Introducing a new interface IAbsentMessageFormatter and its standard
implementation (with the legacy behaviour ??messageKey_locale??).
This is a proposed fix for #328

I would love to have your feedback on this.

Thanks 
