### PR TITLE
Fix NodeLocalVariablesMap.contentsHash(), unnecessary super.hashcode()

### DIFF
--- a/src/main/java/org/thymeleaf/dom/Node.java
+++ b/src/main/java/org/thymeleaf/dom/Node.java
@@ -1163,7 +1163,7 @@ public abstract class Node implements Serializable {
         int contentsHash() {
             //noinspection MagicNumber
             final int prime = 31;
-            int result = super.hashCode();
+            int result = 17;
             result = prime * result + System.identityHashCode(this);
             for (final Map.Entry<String,Object> entry : this.entrySet()) {
                 final String key = entry.getKey();


### PR DESCRIPTION
I'm running load test on spring4.1, compare thymeleaf 2.1.4 with jsp.
Thymeleaf spend about twice cpu usage than jsp.

I use hprof sampler and it showed contentsHash() top cpu usage.
I think the cause is NodeLocalVariablesMap.contentsHash() call super.hachCode(), that is map elements iterate all 2 times.

Related User Forum Thread
http://forum.thymeleaf.org/Thymeleaf-taking-up-high-CPU-with-small-users-td4028966.html

I would like to have your feedback.
Thanks.
