### PR TITLE
2.1 dev

### DIFF
--- a/src/main/java/org/thymeleaf/Configuration.java
+++ b/src/main/java/org/thymeleaf/Configuration.java
@@ -920,13 +920,9 @@ public final class Configuration {
         }
 
         public int compare(final ITemplateResolver o1, final ITemplateResolver o2) {
-            if (o1.getOrder() == null) {
-                return -1;
-            }
-            if (o2.getOrder() == null) {
-                return 1;
-            }
-            return o1.getOrder().compareTo(o2.getOrder());
+        	Integer order1 = null == o1.getOrder() ? Integer.MAX_VALUE : o1.getOrder();
+        	Integer order2 = null == o2.getOrder() ? Integer.MAX_VALUE : o2.getOrder();
+        	return order1.compareTo(order2);
         }
 
     }

--- a/src/main/java/org/thymeleaf/templateresolver/ITemplateResolver.java
+++ b/src/main/java/org/thymeleaf/templateresolver/ITemplateResolver.java
@@ -84,6 +84,11 @@ public interface ITemplateResolver {
      *   Return the order in which this template resolver will be executed in the
      *   chain when several template resolvers are set for the same Template Engine.
      * </p>
+     * <p>
+     *   Higher values are interpreted as lower priority. A null value is interpreted
+     *   as lowest priority, and thus the template resolver will appear last in the
+     *   chain.
+     * </p>
      * 
      * @return the order of this resolver in the chain.
      */


### PR DESCRIPTION
Implementation of #406 - TemplateResolverComparator now interprets null value of ITemplateResolver.getOrder() as lowest priority (Integer.MAX_VALUE)

I agree to the terms laid out in https://github.com/thymeleaf/thymeleaf/blob/3.0-master/CONTRIBUTING.markdown
