### PR TITLE
Make dialectPrefix accessible to subclasses

### DIFF
--- a/src/main/java/org/thymeleaf/processor/element/AbstractElementModelProcessor.java
+++ b/src/main/java/org/thymeleaf/processor/element/AbstractElementModelProcessor.java
@@ -71,6 +71,9 @@ public abstract class AbstractElementModelProcessor
 
     }
 
+    protected final String getDialectPrefix() {
+        return this.dialectPrefix;
+    }
 
     public final MatchingElementName getMatchingElementName() {
         return this.matchingElementName;


### PR DESCRIPTION
Just noticed that, even though this value passes through the processor, it's never then accessible by processors that might need it later, eg: my case where I was trying to find an element with the `layout:fragment` attribute on it, but I couldn't be sure if `layout` was the configured prefix (I seem to recall that dialect prefixes are configurable by devs at runtime?).

So I just added a `protected` accessor method.

@thymeleaf/thymeleaf-team 
