### PR TITLE
Make IContext available in ITemplateResolver

### DIFF
--- a/src/main/java/org/thymeleaf/engine/TemplateManager.java
+++ b/src/main/java/org/thymeleaf/engine/TemplateManager.java
@@ -248,7 +248,7 @@ public final class TemplateManager {
          * Resolve the template
          */
         final TemplateResolution templateResolution =
-                resolveTemplate(this.configuration, ownerTemplate, template, templateResolutionAttributes, failIfNotExists);
+                resolveTemplate(this.configuration, context, ownerTemplate, template, templateResolutionAttributes, failIfNotExists);
 
 
         /*
@@ -605,7 +605,7 @@ public final class TemplateManager {
          * Resolve the template
          */
         final TemplateResolution templateResolution =
-                resolveTemplate(this.configuration, null, template, templateResolutionAttributes, true);
+                resolveTemplate(this.configuration, context, null, template, templateResolutionAttributes, true);
 
 
         /*
@@ -749,7 +749,7 @@ public final class TemplateManager {
          * Resolve the template
          */
         final TemplateResolution templateResolution =
-                resolveTemplate(this.configuration, null, template, templateResolutionAttributes, true);
+                resolveTemplate(this.configuration, context, null, template, templateResolutionAttributes, true);
 
 
         /*
@@ -823,6 +823,7 @@ public final class TemplateManager {
 
     private static TemplateResolution resolveTemplate(
             final IEngineConfiguration configuration,
+            final IContext context,
             final String ownerTemplate,
             final String template,
             final Map<String, Object> templateResolutionAttributes,
@@ -837,7 +838,7 @@ public final class TemplateManager {
         for (final ITemplateResolver templateResolver : configuration.getTemplateResolvers()) {
 
             final TemplateResolution templateResolution =
-                    templateResolver.resolveTemplate(configuration, ownerTemplate, template, templateResolutionAttributes);
+                    templateResolver.resolveTemplate(configuration, context, ownerTemplate, template, templateResolutionAttributes);
             if (templateResolution != null) {
                 if (logger.isTraceEnabled()) {
                     logger.trace(

--- a/src/main/java/org/thymeleaf/templateresolver/AbstractTemplateResolver.java
+++ b/src/main/java/org/thymeleaf/templateresolver/AbstractTemplateResolver.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import org.thymeleaf.IEngineConfiguration;
 import org.thymeleaf.cache.ICacheEntryValidity;
+import org.thymeleaf.context.IContext;
 import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresource.ITemplateResource;
 import org.thymeleaf.util.PatternSpec;
@@ -217,7 +218,7 @@ public abstract class AbstractTemplateResolver implements ITemplateResolver {
      * </p>
      * <p>
      *   If this <em>existence check</em> is enabled and a resource is determined to not exist,
-     *   {@link ITemplateResolver#resolveTemplate(IEngineConfiguration, String, String, Map)} will return <tt>null</tt>.
+     *   {@link ITemplateResolver#resolveTemplate(IEngineConfiguration, IContext, String, String, Map)} will return <tt>null</tt>.
      * </p>
      *
      * @return <tt>true</tt> if resource existence will be checked, <tt>false</tt> if not
@@ -252,7 +253,7 @@ public abstract class AbstractTemplateResolver implements ITemplateResolver {
      * </p>
      * <p>
      *   If this <em>existence check</em> is enabled and a resource is determined to not exist,
-     *   {@link ITemplateResolver#resolveTemplate(IEngineConfiguration, String, String, Map)} will return <tt>null</tt>.
+     *   {@link ITemplateResolver#resolveTemplate(IEngineConfiguration, IContext, String, String, Map)} will return <tt>null</tt>.
      * </p>
      *
      * @param checkExistence <tt>true</tt> if resource existence should be checked, <tt>false</tt> if not
@@ -340,9 +341,10 @@ public abstract class AbstractTemplateResolver implements ITemplateResolver {
 
 
     public final TemplateResolution resolveTemplate(
-            final IEngineConfiguration configuration,
-            final String ownerTemplate, final String template,
-            final Map<String, Object> templateResolutionAttributes) {
+        final IEngineConfiguration configuration,
+        final IContext context,
+        final String ownerTemplate, final String template,
+        final Map<String, Object> templateResolutionAttributes) {
 
         Validate.notNull(configuration, "Engine Configuration cannot be null");
         // ownerTemplate CAN be null

--- a/src/main/java/org/thymeleaf/templateresolver/ITemplateResolver.java
+++ b/src/main/java/org/thymeleaf/templateresolver/ITemplateResolver.java
@@ -22,6 +22,7 @@ package org.thymeleaf.templateresolver;
 import java.util.Map;
 
 import org.thymeleaf.IEngineConfiguration;
+import org.thymeleaf.context.IContext;
 import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresource.ITemplateResource;
 
@@ -142,6 +143,7 @@ public interface ITemplateResolver {
      * </p>
      * 
      * @param configuration the engine configuration.
+     * @param context the context
      * @param ownerTemplate the containing template from which we want to resolve a new one as a fragment. Can be null.
      * @param template the template to be resolved (usually its name).
      * @param templateResolutionAttributes the template resolution attributes to be used (usually coming from a
@@ -150,8 +152,9 @@ public interface ITemplateResolver {
      *         template could not be resolved.
      */
     public TemplateResolution resolveTemplate(
-            final IEngineConfiguration configuration,
-            final String ownerTemplate, final String template,
-            final Map<String, Object> templateResolutionAttributes);
+        final IEngineConfiguration configuration,
+        final IContext context,
+        final String ownerTemplate, final String template,
+        final Map<String, Object> templateResolutionAttributes);
 
 }


### PR DESCRIPTION
Making `IContext` available in `ITemplateResolver` allows accessing objects added by the caller of `ITemplateEngine#process(...)`.

This is e.g. required for using objects managed by the enclosing framework (`ResourceResolver` in [Sling](https://sling.apache.org)):

[`SlingResourceTemplateResolver#resolveTemplate(IEngineConfiguration, IContext, String, String, Map<String, Object>):TemplateResolution`](https://github.com/apache/sling/blob/trunk/contrib/scripting/org.apache.sling.scripting.thymeleaf/src/main/java/org/apache/sling/scripting/thymeleaf/internal/SlingResourceTemplateResolver.java#L114)

Template resolution attributes are not an option as they are used as cache keys.
