### PR TITLE
Move nullcheck of dereferenced context variable

### DIFF
--- a/src/main/java/org/thymeleaf/engine/AbstractGatheringModelProcessable.java
+++ b/src/main/java/org/thymeleaf/engine/AbstractGatheringModelProcessable.java
@@ -74,12 +74,6 @@ abstract class AbstractGatheringModelProcessable implements IGatheringModelProce
         this.flowController = flowController;
         this.buildTimeSkipBody = buildTimeSkipBody;
         this.buildTimeSkipCloseTag = buildTimeSkipCloseTag;
-        this.syntheticModel = new Model(configuration, context.getTemplateMode());
-        this.processorExecutionVars = processorExecutionVars.cloneVars();
-
-        this.gatheringFinished = false;
-
-        this.modelLevel = 0;
 
         if (this.context == null) {
             throw new TemplateProcessingException(
@@ -90,7 +84,10 @@ abstract class AbstractGatheringModelProcessable implements IGatheringModelProce
                     " interface");
         }
 
-
+        this.syntheticModel = new Model(configuration, context.getTemplateMode());
+        this.processorExecutionVars = processorExecutionVars.cloneVars();
+        this.gatheringFinished = false;
+        this.modelLevel = 0;
     }
 
 


### PR DESCRIPTION
These changes are meant to avoid possible NPE by bringing the nullcheck on `context` higher into the method. Previously, the context was dereferenced in this line above the nullcheck:

`this.syntheticModel = new Model(configuration, context.getTemplateMode());`

And just a few lines above that there is the `this.context = context;`.
