### PR TITLE
Avoid NPE upon throwing TextParseException

### DIFF
--- a/src/main/java/org/thymeleaf/templateparser/text/EventProcessorTextHandler.java
+++ b/src/main/java/org/thymeleaf/templateparser/text/EventProcessorTextHandler.java
@@ -215,7 +215,7 @@ final class EventProcessorTextHandler extends AbstractChainedTextHandler {
         }
 
         throw new TextParseException(
-                "Malformed template: " + (peek.length > 0? ("closing element \"" + new String(buffer, offset, len) + "\"") : ("unnamed closing element")) + " is never open", line, col);
+                "Malformed template: unnamed closing element is never opened", line, col);
 
     }
 


### PR DESCRIPTION
The `peek` array is guaranteed to be `null` at the point the `TextParseException` is being thrown in line 217 due to the line 204 nullcheck.

I assumed the same exception message as if `peek` array is empty.
