### PR TITLE
Make Thymleaf cache more testable, enabling cache metrics monitoring.

### DIFF
--- a/src/main/java/org/thymeleaf/cache/StandardCache.java
+++ b/src/main/java/org/thymeleaf/cache/StandardCache.java
@@ -85,6 +85,12 @@ public final class StandardCache<K, V> implements ICache<K,V> {
 
     public StandardCache(final String name, final boolean useSoftReferences,
                          final int initialCapacity, final int maxSize, final ICacheEntryValidityChecker<? super K, ? super V> entryValidityChecker,
+                         final Logger logger) {
+        this(name, useSoftReferences, initialCapacity, maxSize, entryValidityChecker, logger, false);
+    }
+
+    public StandardCache(final String name, final boolean useSoftReferences,
+                         final int initialCapacity, final int maxSize, final ICacheEntryValidityChecker<? super K, ? super V> entryValidityChecker,
                          final Logger logger, final boolean enableCounters) {
 
         super();
@@ -101,7 +107,7 @@ public final class StandardCache<K, V> implements ICache<K,V> {
         this.logger = logger;
         this.traceExecution = (logger != null && logger.isTraceEnabled());
 
-        this.enableCounters = enableCounters;
+        this.enableCounters = this.traceExecution || enableCounters;
 
         this.dataContainer =
                 new CacheDataContainer<K,V>(this.name, initialCapacity, maxSize, this.traceExecution, this.logger);
@@ -251,7 +257,7 @@ public final class StandardCache<K, V> implements ICache<K,V> {
     // -----
 
     private void incrementReportEntity(final AtomicLong entity) {
-        if (this.traceExecution || this.enableCounters) {
+        if (this.enableCounters) {
             entity.incrementAndGet();
         }
     }

--- a/src/main/java/org/thymeleaf/cache/StandardCache.java
+++ b/src/main/java/org/thymeleaf/cache/StandardCache.java
@@ -31,7 +31,7 @@ import org.thymeleaf.util.Validate;
 
 
 /**
- * 
+ *
  *
  * @author Daniel Fern&aacute;ndez
  * @author Guven Demir
@@ -41,14 +41,14 @@ import org.thymeleaf.util.Validate;
  * @param <K> The type of the cache keys
  * @param <V> The type of the cache values
  */
-public final class StandardCache<K, V> implements ICache<K,V> {
+public class StandardCache<K, V> implements ICache<K,V> {
 
-    
+
     private static final long REPORT_INTERVAL = 300000L; // 5 minutes
-    private static final String REPORT_FORMAT = 
+    private static final String REPORT_FORMAT =
             "[THYMELEAF][*][*][*][CACHE_REPORT] %8s elements | %12s puts | %12s gets | %12s hits | %12s misses - [%s]";
     private volatile long lastExecution = System.currentTimeMillis();
-    
+
     private final String name;
     private final boolean useSoftReferences;
     private final int maxSize;
@@ -57,125 +57,115 @@ public final class StandardCache<K, V> implements ICache<K,V> {
 
     private final boolean traceExecution;
     private final Logger logger;
-    
-    private final AtomicLong getCount;
-    private final AtomicLong putCount;
-    private final AtomicLong hitCount;
-    private final AtomicLong missCount;
-    
-    
 
-    
-    
-    
-    
+    private volatile long getCount;
+    private volatile long putCount;
+    private volatile long hitCount;
+    private volatile long missCount;
 
-    public StandardCache(final String name, final boolean useSoftReferences, 
-            final int initialCapacity, final Logger logger) {
+
+
+    public StandardCache(final String name, final boolean useSoftReferences,
+                         final int initialCapacity, final Logger logger) {
         this(name, useSoftReferences, initialCapacity, -1, null, logger);
     }
 
-    public StandardCache(final String name, final boolean useSoftReferences, 
-            final int initialCapacity, final ICacheEntryValidityChecker<? super K, ? super V> entryValidityChecker, 
-            final Logger logger) {
+    public StandardCache(final String name, final boolean useSoftReferences,
+                         final int initialCapacity, final ICacheEntryValidityChecker<? super K, ? super V> entryValidityChecker,
+                         final Logger logger) {
         this(name, useSoftReferences, initialCapacity, -1, entryValidityChecker, logger);
     }
 
-    public StandardCache(final String name, final boolean useSoftReferences, 
-            final int initialCapacity, final int maxSize, final Logger logger) {
+    public StandardCache(final String name, final boolean useSoftReferences,
+                         final int initialCapacity, final int maxSize, final Logger logger) {
         this(name, useSoftReferences, initialCapacity, maxSize, null, logger);
     }
 
-    public StandardCache(final String name, final boolean useSoftReferences, 
-            final int initialCapacity, final int maxSize, final ICacheEntryValidityChecker<? super K, ? super V> entryValidityChecker, 
-            final Logger logger) {
-        
+    public StandardCache(final String name, final boolean useSoftReferences,
+                         final int initialCapacity, final int maxSize, final ICacheEntryValidityChecker<? super K, ? super V> entryValidityChecker,
+                         final Logger logger) {
+
         super();
 
         Validate.notEmpty(name, "Name cannot be null or empty");
         Validate.isTrue(initialCapacity > 0, "Initial capacity must be > 0");
         Validate.isTrue(maxSize != 0, "Cache max size must be either -1 (no limit) or > 0");
-        
+
         this.name = name;
         this.useSoftReferences = useSoftReferences;
         this.maxSize = maxSize;
         this.entryValidityChecker = entryValidityChecker;
-        
+
         this.logger = logger;
         this.traceExecution = (logger != null && logger.isTraceEnabled());
-        
-        this.dataContainer = 
+
+        this.dataContainer =
                 new CacheDataContainer<K,V>(this.name, initialCapacity, maxSize, this.traceExecution, this.logger);
-        
-        this.getCount = new AtomicLong(0);
-        this.putCount = new AtomicLong(0);
-        this.hitCount = new AtomicLong(0);
-        this.missCount = new AtomicLong(0);
 
         if (this.logger != null) {
             if (this.maxSize < 0) {
-                this.logger.debug("[THYMELEAF][CACHE_INITIALIZE] Initializing cache {}. Soft references {}.", 
+                this.logger.debug("[THYMELEAF][CACHE_INITIALIZE] Initializing cache {}. Soft references {}.",
                         this.name, (this.useSoftReferences? "are used" : "not used"));
             } else {
-                this.logger.debug("[THYMELEAF][CACHE_INITIALIZE] Initializing cache {}. Max size: {}. Soft references {}.", 
+                this.logger.debug("[THYMELEAF][CACHE_INITIALIZE] Initializing cache {}. Max size: {}. Soft references {}.",
                         new Object[] {this.name, Integer.valueOf(this.maxSize), (this.useSoftReferences? "are used" : "not used")});
             }
         }
-        
+
     }
 
 
-    
-    
+
+
     // -----
 
-    
-    
+
+
     public void put(final K key, final V value) {
 
-        incrementReportEntity(this.putCount);
-        
+        incrementPutCount();
+
         final CacheEntry<V> entry = new CacheEntry<V>(value, this.useSoftReferences);
-        
+
         // newSize will be -1 if traceExecution is false
         final int newSize = this.dataContainer.put(key, entry);
-        
+
         if (this.traceExecution) {
             this.logger.trace(
-                    "[THYMELEAF][{}][{}][CACHE_ADD][{}] Adding cache entry in cache \"{}\" for key \"{}\". New size is {}.", 
+                    "[THYMELEAF][{}][{}][CACHE_ADD][{}] Adding cache entry in cache \"{}\" for key \"{}\". New size is {}.",
                     new Object[] {TemplateEngine.threadIndex(), this.name, Integer.valueOf(newSize), this.name, key, Integer.valueOf(newSize)});
         }
-        
-        outputReportIfNeeded();
-        
-    }
-    
 
-    
+        outputReportIfNeeded();
+
+    }
+
+
+
     public V get(final K key) {
         return get(key, this.entryValidityChecker);
     }
-    
 
-    
+
+
     public V get(final K key, final ICacheEntryValidityChecker<? super K, ? super V> validityChecker) {
-        
-        incrementReportEntity(this.getCount);
-        
+
+        incrementGetCount();
+
         final CacheEntry<V> resultEntry = this.dataContainer.get(key);
-        
+
         if (resultEntry == null) {
-            incrementReportEntity(this.missCount);
+            incrementMissCount();
             if (this.traceExecution) {
                 this.logger.trace(
-                        "[THYMELEAF][{}][{}][CACHE_MISS] Cache miss in cache \"{}\" for key \"{}\".", 
+                        "[THYMELEAF][{}][{}][CACHE_MISS] Cache miss in cache \"{}\" for key \"{}\".",
                         new Object[] {TemplateEngine.threadIndex(), this.name, this.name, key});
             }
             outputReportIfNeeded();
             return null;
         }
 
-        final V resultValue = 
+        final V resultValue =
                 resultEntry.getValueIfStillValid(this.name, key, validityChecker, this.traceExecution, this.logger);
         if (resultValue == null) {
             final int newSize = this.dataContainer.remove(key);
@@ -184,24 +174,24 @@ public final class StandardCache<K, V> implements ICache<K,V> {
                         "[THYMELEAF][{}][{}][CACHE_REMOVE][{}] Removing cache entry in cache \"{}\" (Entry \"{}\" is not valid anymore). New size is {}.",
                         new Object[] {TemplateEngine.threadIndex(), this.name, Integer.valueOf(newSize), this.name, key, Integer.valueOf(newSize)});
                 this.logger.trace(
-                        "[THYMELEAF][{}][{}][CACHE_MISS] Cache miss in cache \"{}\" for key \"{}\".", 
+                        "[THYMELEAF][{}][{}][CACHE_MISS] Cache miss in cache \"{}\" for key \"{}\".",
                         new Object[] {TemplateEngine.threadIndex(), this.name, this.name, key});
             }
-            incrementReportEntity(this.missCount);
+            incrementMissCount();
             outputReportIfNeeded();
             return null;
         }
-        
+
         if (this.traceExecution) {
             this.logger.trace(
-                    "[THYMELEAF][{}][{}][CACHE_HIT] Cache hit in cache \"{}\" for key \"{}\".", 
+                    "[THYMELEAF][{}][{}][CACHE_HIT] Cache hit in cache \"{}\" for key \"{}\".",
                     new Object[] {TemplateEngine.threadIndex(), this.name, this.name, key});
         }
-        
-        incrementReportEntity(this.hitCount);
+
+        incrementHitCount();
         outputReportIfNeeded();
         return resultValue;
-        
+
     }
 
 
@@ -219,48 +209,46 @@ public final class StandardCache<K, V> implements ICache<K,V> {
         return this.dataContainer.keySet();
     }
 
-    
+
 
     public void clear() {
-        
+
         this.dataContainer.clear();
-        
+
         if (this.traceExecution) {
             this.logger.trace(
-                    "[THYMELEAF][{}][*][{}][CACHE_REMOVE][0] Removing ALL cache entries in cache \"{}\". New size is 0.", 
+                    "[THYMELEAF][{}][*][{}][CACHE_REMOVE][0] Removing ALL cache entries in cache \"{}\". New size is 0.",
                     new Object[] {TemplateEngine.threadIndex(), this.name, this.name});
         }
-        
+
     }
-    
-    
-    
+
+
+
     public void clearKey(final K key) {
 
         final int newSize = this.dataContainer.remove(key);
-        
+
         if (this.traceExecution && newSize != -1) {
             this.logger.trace(
-                    "[THYMELEAF][{}][*][{}][CACHE_REMOVE][{}] Removed cache entry in cache \"{}\" for key \"{}\". New size is {}.", 
+                    "[THYMELEAF][{}][*][{}][CACHE_REMOVE][{}] Removed cache entry in cache \"{}\" for key \"{}\". New size is {}.",
                     new Object[] {TemplateEngine.threadIndex(), this.name, Integer.valueOf(newSize), this.name, key, Integer.valueOf(newSize)});
         }
-        
+
     }
-    
-    
-    
+
+
+
     // -----
 
-    
-    
     public String getName() {
         return this.name;
     }
-    
+
     public boolean hasMaxSize() {
         return (this.maxSize > 0);
     }
-    
+
     public int getMaxSize() {
         return this.maxSize;
     }
@@ -273,22 +261,36 @@ public final class StandardCache<K, V> implements ICache<K,V> {
         return this.dataContainer.size();
     }
 
-    
-    
-    // -----
+    public long getPutCount (){  return putCount;}
+    public long getGetCount (){  return getCount;}
+    public long getHitCount (){  return hitCount;}
+    public long getMissCount (){ return missCount;}
 
-    
-    private void incrementReportEntity(final AtomicLong entity) {
-        if (this.traceExecution) {
-            entity.incrementAndGet();
-        }
+
+    private void incrementPutCount (){   putCount++;}
+    private void incrementGetCount (){   getCount++;}
+    private void incrementHitCount (){   hitCount++;}
+    private void incrementMissCount (){  missCount++;}
+
+    public double getHitRatio() {
+        return 1 - getMissRatio();
     }
 
-    
+    public double getMissRatio() {
+        long missCount = getMissCount();
+        long getCount = getGetCount();
+
+        if ( missCount == 0 || getCount == 0 )
+            return 0;
+
+        return  ((double)getMissCount()) / getGetCount(); }
+
+    // -----
+
     private void outputReportIfNeeded() {
-        
+
         if (this.traceExecution) { // fail fast
-            
+
             final long currentTime = System.currentTimeMillis();
             if ((currentTime - this.lastExecution) >= REPORT_INTERVAL) { // first check without need to sync
                 synchronized (this) {
@@ -296,41 +298,39 @@ public final class StandardCache<K, V> implements ICache<K,V> {
                         this.logger.trace(
                                 String.format(REPORT_FORMAT,
                                         Integer.valueOf(size()),
-                                        Long.valueOf(this.putCount.get()),
-                                        Long.valueOf(this.getCount.get()),
-                                        Long.valueOf(this.hitCount.get()),
-                                        Long.valueOf(this.missCount.get()),
+                                        this.putCount,
+                                        this.getCount,
+                                        this.hitCount,
+                                        this.missCount,
                                         this.name));
                         this.lastExecution = currentTime;
                     }
                 }
             }
-            
+
         }
-        
+
     }
-    
-    
 
 
 
 
     static final class CacheDataContainer<K,V> {
-        
+
         private final String name;
         private final boolean sizeLimit;
         private final int maxSize;
         private final boolean traceExecution;
         private final Logger logger;
-        
+
         private final ConcurrentHashMap<K,CacheEntry<V>> container;
         private final Object[] fifo;
         private int fifoPointer;
 
 
         CacheDataContainer(final String name, final int initialCapacity,
-                final int maxSize, final boolean traceExecution, final Logger logger) {
-            
+                           final int maxSize, final boolean traceExecution, final Logger logger) {
+
             super();
 
             this.name = name;
@@ -346,7 +346,7 @@ public final class StandardCache<K, V> implements ICache<K,V> {
             this.fifoPointer = 0;
             this.traceExecution = traceExecution;
             this.logger = logger;
-            
+
         }
 
 
@@ -363,26 +363,26 @@ public final class StandardCache<K, V> implements ICache<K,V> {
 
         public int put(final K key, final CacheEntry<V> value) {
             if (this.traceExecution) {
-                return putWithTracing(key, value); 
+                return putWithTracing(key, value);
             }
             return putWithoutTracing(key, value);
         }
 
-        
+
         private int putWithoutTracing(final K key, final CacheEntry<V> value) {
             // If we are not tracing, it's better to avoid the size() operation which has
             // some performance implications in ConcurrentHashMap (iteration and counting these maps
             // is slow if they are big)
-            
+
             final CacheEntry<V> existing = this.container.putIfAbsent(key, value);
             if (existing != null) {
                 // When not in 'trace' mode, will always return -1
                 return -1;
             }
-                    
+
             if (this.sizeLimit) {
                 synchronized (this.fifo) {
-                    final Object removedKey = this.fifo[this.fifoPointer]; 
+                    final Object removedKey = this.fifo[this.fifoPointer];
                     if (removedKey != null) {
                         this.container.remove(removedKey);
                     }
@@ -390,9 +390,9 @@ public final class StandardCache<K, V> implements ICache<K,V> {
                     this.fifoPointer = (this.fifoPointer + 1) % this.maxSize;
                 }
             }
-            
+
             return -1;
-            
+
         }
 
         private synchronized int putWithTracing(final K key, final CacheEntry<V> value) {
@@ -400,13 +400,13 @@ public final class StandardCache<K, V> implements ICache<K,V> {
             final CacheEntry<V> existing = this.container.putIfAbsent(key, value);
             if (existing == null) {
                 if (this.sizeLimit) {
-                    final Object removedKey = this.fifo[this.fifoPointer]; 
+                    final Object removedKey = this.fifo[this.fifoPointer];
                     if (removedKey != null) {
                         final CacheEntry<V> removed = this.container.remove(removedKey);
                         if (removed != null) {
                             final Integer newSize = Integer.valueOf(this.container.size());
                             this.logger.trace(
-                                    "[THYMELEAF][{}][{}][CACHE_REMOVE][{}] Max size exceeded for cache \"{}\". Removing entry for key \"{}\". New size is {}.", 
+                                    "[THYMELEAF][{}][{}][CACHE_REMOVE][{}] Max size exceeded for cache \"{}\". Removing entry for key \"{}\". New size is {}.",
                                     new Object[] {TemplateEngine.threadIndex(), this.name, newSize, this.name, removedKey, newSize});
                         }
                     }
@@ -415,18 +415,18 @@ public final class StandardCache<K, V> implements ICache<K,V> {
                 }
             }
             return this.container.size();
-            
+
         }
 
-        
+
         public int remove(final K key) {
             if (this.traceExecution) {
-                return removeWithTracing(key); 
+                return removeWithTracing(key);
             }
             return removeWithoutTracing(key);
         }
 
-        
+
         private int removeWithoutTracing(final K key) {
             // FIFO is also updated to avoid 'removed' keys remaining at FIFO (which could end up reducing cache size to 1)
             final CacheEntry<V> removed = this.container.remove(key);
@@ -443,7 +443,7 @@ public final class StandardCache<K, V> implements ICache<K,V> {
             return -1;
         }
 
-        
+
         private synchronized int removeWithTracing(final K key) {
             // FIFO is also updated to avoid 'removed' keys remaining at FIFO (which could end up reducing cache size to 1)
             final CacheEntry<V> removed = this.container.remove(key);
@@ -466,12 +466,12 @@ public final class StandardCache<K, V> implements ICache<K,V> {
         public void clear() {
             this.container.clear();
         }
-        
-        
+
+
         public int size() {
             return this.container.size();
         }
-        
+
     }
 
 
@@ -481,13 +481,13 @@ public final class StandardCache<K, V> implements ICache<K,V> {
 
         private final SoftReference<V> cachedValueReference;
         private final long creationTimeInMillis;
-        
+
         // Although we will use the reference for normal operation for cleaner code, this
         // variable will act as an "anchor" to avoid the value to be cleaned if we don't
         // want the reference type to be "soft"
-        @SuppressWarnings("unused") 
+        @SuppressWarnings("unused")
         private final V cachedValueAnchor;
-        
+
 
         CacheEntry(final V cachedValue, final boolean useSoftReferences) {
 
@@ -499,9 +499,9 @@ public final class StandardCache<K, V> implements ICache<K,V> {
 
         }
 
-        public <K> V getValueIfStillValid(final String cacheMapName, 
-                final K key, final ICacheEntryValidityChecker<? super K, ? super V> checker,
-                final boolean traceExecution, final Logger logger) {
+        public <K> V getValueIfStillValid(final String cacheMapName,
+                                          final K key, final ICacheEntryValidityChecker<? super K, ? super V> checker,
+                                          final boolean traceExecution, final Logger logger) {
 
             final V cachedValue = this.cachedValueReference.get();
 
@@ -510,7 +510,7 @@ public final class StandardCache<K, V> implements ICache<K,V> {
                 if (traceExecution) {
                     logger.trace(
                             "[THYMELEAF][{}][*][{}][CACHE_DELETED_REFERENCES] Some entries at cache \"{}\" " +
-                            "seem to have been sacrificed by the Garbage Collector (soft references).",
+                                    "seem to have been sacrificed by the Garbage Collector (soft references).",
                             new Object[] {TemplateEngine.threadIndex(), cacheMapName, cacheMapName});
                 }
                 return null;

--- a/src/main/java/org/thymeleaf/cache/StandardCacheManager.java
+++ b/src/main/java/org/thymeleaf/cache/StandardCacheManager.java
@@ -90,7 +90,12 @@ public class StandardCacheManager extends AbstractCacheManager {
      * Default template cache maximum size: 50
      */
     public static final int DEFAULT_TEMPLATE_CACHE_MAX_SIZE = 50;
-    
+
+    /**
+     * Default template cache "enable counters" flag: false
+     */
+    public static final boolean DEFAULT_TEMPLATE_CACHE_ENABLE_COUNTERS = false;
+
     /**
      * Default template cache "use soft references" flag: true
      */
@@ -124,10 +129,15 @@ public class StandardCacheManager extends AbstractCacheManager {
     public static final int DEFAULT_FRAGMENT_CACHE_MAX_SIZE = 300;
     
     /**
+     * Default fragment cache "enable counters" flag: false
+     */
+    public static final boolean DEFAULT_FRAGMENT_CACHE_ENABLE_COUNTERS = false;
+
+    /**
      * Default fragment cache "use soft references" flag: true
      */
     public static final boolean DEFAULT_FRAGMENT_CACHE_USE_SOFT_REFERENCES = true;
-    
+
     /**
      * Default fragment cache logger name: null (default behaviour = org.thymeleaf.TemplateEngine.cache.FRAGMENT_CACHE)
      */
@@ -156,6 +166,11 @@ public class StandardCacheManager extends AbstractCacheManager {
     public static final int DEFAULT_MESSAGE_CACHE_MAX_SIZE = 300;
     
     /**
+     * Default message cache "enable counters" flag: false
+     */
+    public static final boolean DEFAULT_MESSAGE_CACHE_ENABLE_COUNTERS = false;
+
+    /**
      * Default message cache "use soft references" flag: true
      */
     public static final boolean DEFAULT_MESSAGE_CACHE_USE_SOFT_REFERENCES = true;
@@ -170,7 +185,8 @@ public class StandardCacheManager extends AbstractCacheManager {
      */
     public static final ICacheEntryValidityChecker<String,Properties> DEFAULT_MESSAGE_CACHE_VALIDITY_CHECKER = null;
 
-    
+
+
     /**
      * Default expression cache name: "EXPRESSION_CACHE"
      */
@@ -186,6 +202,11 @@ public class StandardCacheManager extends AbstractCacheManager {
      */
     public static final int DEFAULT_EXPRESSION_CACHE_MAX_SIZE = 500;
     
+    /**
+     * Default expression cache "enable counters" flag: false
+     */
+    public static final boolean DEFAULT_EXPRESSION_CACHE_ENABLE_COUNTERS = false;
+
     /**
      * Default expression cache "use soft references" flag: true
      */
@@ -207,6 +228,7 @@ public class StandardCacheManager extends AbstractCacheManager {
     private String templateCacheName = DEFAULT_TEMPLATE_CACHE_NAME;
     private int templateCacheInitialSize = DEFAULT_TEMPLATE_CACHE_INITIAL_SIZE;
     private int templateCacheMaxSize = DEFAULT_TEMPLATE_CACHE_MAX_SIZE;
+    private boolean templateCacheEnableCounters = DEFAULT_TEMPLATE_CACHE_ENABLE_COUNTERS;
     private boolean templateCacheUseSoftReferences = DEFAULT_TEMPLATE_CACHE_USE_SOFT_REFERENCES;
     private String templateCacheLoggerName = DEFAULT_TEMPLATE_CACHE_LOGGER_NAME;
     private ICacheEntryValidityChecker<String,Template> templateCacheValidityChecker = DEFAULT_TEMPLATE_CACHE_VALIDITY_CHECKER;
@@ -214,6 +236,7 @@ public class StandardCacheManager extends AbstractCacheManager {
     private String fragmentCacheName = DEFAULT_FRAGMENT_CACHE_NAME;
     private int fragmentCacheInitialSize = DEFAULT_FRAGMENT_CACHE_INITIAL_SIZE;
     private int fragmentCacheMaxSize = DEFAULT_FRAGMENT_CACHE_MAX_SIZE;
+    private boolean fragmentCacheEnableCounters = DEFAULT_FRAGMENT_CACHE_ENABLE_COUNTERS;
     private boolean fragmentCacheUseSoftReferences = DEFAULT_FRAGMENT_CACHE_USE_SOFT_REFERENCES;
     private String fragmentCacheLoggerName = DEFAULT_FRAGMENT_CACHE_LOGGER_NAME;
     private ICacheEntryValidityChecker<String,List<Node>> fragmentCacheValidityChecker = DEFAULT_FRAGMENT_CACHE_VALIDITY_CHECKER;
@@ -221,6 +244,7 @@ public class StandardCacheManager extends AbstractCacheManager {
     private String messageCacheName = DEFAULT_MESSAGE_CACHE_NAME;
     private int messageCacheInitialSize = DEFAULT_MESSAGE_CACHE_INITIAL_SIZE;
     private int messageCacheMaxSize = DEFAULT_MESSAGE_CACHE_MAX_SIZE;
+    private boolean messageCacheEnableCounters = DEFAULT_MESSAGE_CACHE_ENABLE_COUNTERS;
     private boolean messageCacheUseSoftReferences = DEFAULT_MESSAGE_CACHE_USE_SOFT_REFERENCES;
     private String messageCacheLoggerName = DEFAULT_MESSAGE_CACHE_LOGGER_NAME;
     private ICacheEntryValidityChecker<String,Properties> messageCacheValidityChecker = DEFAULT_MESSAGE_CACHE_VALIDITY_CHECKER;
@@ -228,6 +252,7 @@ public class StandardCacheManager extends AbstractCacheManager {
     private String expressionCacheName = DEFAULT_EXPRESSION_CACHE_NAME;
     private int expressionCacheInitialSize = DEFAULT_EXPRESSION_CACHE_INITIAL_SIZE;
     private int expressionCacheMaxSize = DEFAULT_EXPRESSION_CACHE_MAX_SIZE;
+    private boolean expressionCacheEnableCounters = DEFAULT_EXPRESSION_CACHE_ENABLE_COUNTERS;
     private boolean expressionCacheUseSoftReferences = DEFAULT_EXPRESSION_CACHE_USE_SOFT_REFERENCES;
     private String expressionCacheLoggerName = DEFAULT_EXPRESSION_CACHE_LOGGER_NAME;
     private ICacheEntryValidityChecker<String,Object> expressionCacheValidityChecker = DEFAULT_EXPRESSION_CACHE_VALIDITY_CHECKER;
@@ -238,7 +263,7 @@ public class StandardCacheManager extends AbstractCacheManager {
         super();
     }
 
-    
+
     
     @Override
     protected final ICache<String, Template> initializeTemplateCache() {
@@ -249,7 +274,7 @@ public class StandardCacheManager extends AbstractCacheManager {
         return new StandardCache<String, Template>(
                 getTemplateCacheName(), getTemplateCacheUseSoftReferences(), 
                 getTemplateCacheInitialSize(), maxSize, 
-                getTemplateCacheValidityChecker(), getTemplateCacheLogger());
+                getTemplateCacheValidityChecker(), getTemplateCacheLogger(), getTemplateCacheEnableCounters());
     }
     
     @Override
@@ -261,7 +286,7 @@ public class StandardCacheManager extends AbstractCacheManager {
         return new StandardCache<String, List<Node>>(
                 getFragmentCacheName(), getFragmentCacheUseSoftReferences(), 
                 getFragmentCacheInitialSize(), maxSize, 
-                getFragmentCacheValidityChecker(), getFragmentCacheLogger());
+                getFragmentCacheValidityChecker(), getFragmentCacheLogger(), getFragmentCacheEnableCounters());
     }
 
     
@@ -274,7 +299,7 @@ public class StandardCacheManager extends AbstractCacheManager {
         return new StandardCache<String, Properties>(
                 getMessageCacheName(), getMessageCacheUseSoftReferences(), 
                 getMessageCacheInitialSize(), maxSize, 
-                getMessageCacheValidityChecker(), getMessageCacheLogger());
+                getMessageCacheValidityChecker(), getMessageCacheLogger(), getMessageCacheEnableCounters());
     }
 
     
@@ -287,7 +312,7 @@ public class StandardCacheManager extends AbstractCacheManager {
         return new StandardCache<String, Object>(
                 getExpressionCacheName(), getExpressionCacheUseSoftReferences(), 
                 getExpressionCacheInitialSize(), maxSize, 
-                getExpressionCacheValidityChecker(), getExpressionCacheLogger());
+                getExpressionCacheValidityChecker(), getExpressionCacheLogger(), getExpressionCacheEnableCounters());
     }
     
     
@@ -300,7 +325,11 @@ public class StandardCacheManager extends AbstractCacheManager {
     public boolean getTemplateCacheUseSoftReferences() {
         return this.templateCacheUseSoftReferences;
     }
-    
+
+    private boolean getTemplateCacheEnableCounters() {
+        return this.templateCacheEnableCounters;
+    }
+
     public int getTemplateCacheInitialSize() {
         return this.templateCacheInitialSize;
     }
@@ -335,7 +364,11 @@ public class StandardCacheManager extends AbstractCacheManager {
     public boolean getFragmentCacheUseSoftReferences() {
         return this.fragmentCacheUseSoftReferences;
     }
-    
+
+    private boolean getFragmentCacheEnableCounters() {
+        return this.fragmentCacheEnableCounters;
+    }
+
     public int getFragmentCacheInitialSize() {
         return this.fragmentCacheInitialSize;
     }
@@ -370,7 +403,9 @@ public class StandardCacheManager extends AbstractCacheManager {
     public boolean getMessageCacheUseSoftReferences() {
         return this.messageCacheUseSoftReferences;
     }
-    
+
+    private boolean getMessageCacheEnableCounters() {return this.messageCacheEnableCounters;}
+
     public int getMessageCacheInitialSize() {
         return this.messageCacheInitialSize;
     }
@@ -405,7 +440,11 @@ public class StandardCacheManager extends AbstractCacheManager {
     public boolean getExpressionCacheUseSoftReferences() {
         return this.expressionCacheUseSoftReferences;
     }
-    
+
+    private boolean getExpressionCacheEnableCounters() {
+        return this.expressionCacheEnableCounters;
+    }
+
     public int getExpressionCacheInitialSize() {
         return this.expressionCacheInitialSize;
     }
@@ -458,8 +497,12 @@ public class StandardCacheManager extends AbstractCacheManager {
         this.templateCacheValidityChecker = templateCacheValidityChecker;
     }
 
-    
-    
+    public void setTemplateCacheEnableCounters(boolean templateCacheEnableCounters) {
+        this.templateCacheEnableCounters = templateCacheEnableCounters;
+    }
+
+
+
     public void setFragmentCacheName(final String fragmentCacheName) {
         this.fragmentCacheName = fragmentCacheName;
     }
@@ -482,6 +525,10 @@ public class StandardCacheManager extends AbstractCacheManager {
     
     public void setFragmentCacheValidityChecker(final ICacheEntryValidityChecker<String, List<Node>> fragmentCacheValidityChecker) {
         this.fragmentCacheValidityChecker = fragmentCacheValidityChecker;
+    }
+
+    public void setFragmentCacheEnableCounters(boolean fragmentCacheEnableCounters) {
+        this.fragmentCacheEnableCounters = fragmentCacheEnableCounters;
     }
 
 
@@ -510,8 +557,12 @@ public class StandardCacheManager extends AbstractCacheManager {
         this.messageCacheValidityChecker = messageCacheValidityChecker;
     }
 
-    
-    
+    public void setMessageCacheEnableCounters(boolean messageCacheEnableCounters) {
+        this.messageCacheEnableCounters = messageCacheEnableCounters;
+    }
+
+
+
     public void setExpressionCacheName(final String expressionCacheName) {
         this.expressionCacheName = expressionCacheName;
     }
@@ -536,8 +587,7 @@ public class StandardCacheManager extends AbstractCacheManager {
         this.expressionCacheValidityChecker = expressionCacheValidityChecker;
     }
 
-    
-    
-    
-    
+    public void setExpressionCacheEnableCounters(boolean expressionCacheEnableCounters) {
+        this.expressionCacheEnableCounters = expressionCacheEnableCounters;
+    }
 }


### PR DESCRIPTION
1) Removed final from class definition, by this change  cache is more testable
2) Removed condition that metrics are incremented only at TRACE log level
3) Added getter for the metrics, this  helps in cache monitoring
4) Added hit and miss ratio metric
5) Change metrics variable type from AtomicLong to volatile long -  performance reason.