### PR TITLE
Various edits to CONTRIBUTING.markdown to improve grammar, spelling, and verbiage

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -3,7 +3,7 @@ Contributing to Thymeleaf: Terms and Conditions
 
 ------------------------------------------------------------------------------
 
-Do you want to contribute your work to thymeleaf? Well, then first and most important: **THANK YOU!**
+Do you want to contribute your work to Thymeleaf? Well, then first and most important: **THANK YOU!**
 
 Now, in order to accept your contribution, there are some terms you must expressly agree with, so please
 read them carefully. They might look a bit cumbersome, but they are here just in order to protect
@@ -102,7 +102,7 @@ Note the following only applies to documentation/articles meant to be published 
   - Topic and text structure must be first discussed and agreed upon with the project members.
   - Project members may edit and make small changes to your texts --of which you will be informed-- before
     publishing them.
-  - Format and visual styles must adhere to the thymeleaf website standards, of which you will be informed
+  - Format and visual styles must adhere to the Thymeleaf website standards, of which you will be informed
     by the project members.
 
 

--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -6,11 +6,11 @@ Contributing to Thymeleaf: Terms and Conditions
 Do you want to contribute your work to Thymeleaf? Well, then first and most important: **THANK YOU!**
 
 Now, in order to accept your contribution, there are some terms you must expressly agree with, so please
-read them carefully. They might look a bit cumbersome, but they are here just in order to protect
-you, your contribution, and especially the project's future.
+read them carefully. They may seem a bit cumbersome but they are there to protect you, your contribution,
+and most importantly, the project's future.
 
 **Important**: submitting any contributions to the Thymeleaf project implies your **full acceptance of these terms**,
-including the *"Thymeleaf Individual Contributor License Agreement"* detailed at the end.
+including the *"Thymeleaf Individual Contributor License Agreement"* detailed at the end of this document.
 
 
 Who can contribute?
@@ -20,7 +20,7 @@ Anyone, with the unique condition that he/she must be a **private individual**, 
 his/her own name, and not being endorsed in their contributed work by any company or government.
 
 Note that this condition will not only refer to the ownership of the effort invested in contributing
-to the project, but also to the fact that *no private or public company will be mentioned as a a part
+to the project, but also to the fact that *no private or public company will be mentioned as a part
 of your contribution on the project's website or code*, including but not limited to web/email addresses
 or package names.
 
@@ -29,25 +29,25 @@ What is the first step to be taken?
 -----------------------------------
 
 First of all, **talk to the [project members](http://www.thymeleaf.org/team.html)** (an email should do) about
-your ideas: new features, fixes, documentation... whatever you would like to contribute to the project. Let we
+your ideas: new features, fixes, documentation... whatever you would like to contribute to the project. Let us
 discuss the possibilities with you so that we make sure your contribution goes in the right direction and aligns
 with the project's standards, intentions and roadmap.
 
 
-How will your relation with the Thymeleaf project be?
------------------------------------------------------
+How will your involvement with the Thymeleaf project work?
+----------------------------------------------------------
 
-Your contributions will have the form of GitHub *pull requests*. Note that contributors do not
+All contributions are submitted in the form of GitHub *pull requests*. Note that contributors do not
 have read+write (or *pull+push*) access to the project repositories, only project *members* do.
 
 Also, please understand that *not all pull requests will be accepted and merged into the project's
-repositories*. Talking about your planned contributions with the project members before creating pull requests
-will maximize the possibilities of your contributions being accepted.
+repositories*. Talk about your planned contributions with the project members before creating pull
+requests so you can maximize the possibility of your contributions being accepted.
 
-Once your contribution is approved, you will be listed as a *contributor* at the
+Once your contribution is approved, you will be listed as a *contributor* on the
 [Thymeleaf Team page](http://www.thymeleaf.org/team.html). You can opt-out of this if you want.
-Also, you will be `@author` for any new Java classes that you write and also co-`@author` to any existing classes to
-which you make significant changes. You can also opt-out of this if you want.  
+Also, you will be `@author` for any new Java classes that you write and also co-`@author` of any
+existing classes to which you make significant changes. You can also opt-out of this if you want.  
 
 
 About the code you contribute
@@ -66,28 +66,30 @@ About the code you contribute
   - All comments, names of classes and variables, log messages, etc. must be **in English**.
   - All `.java` files must include the standard Thymeleaf copyright header.
   - All your code should follow the Java Code Conventions regarding variable/method/class naming.
-  - Maximum line size is 120 characters.
+  - Maximum line length is 120 characters.
   - Indentation should be made with 4 spaces, not tabs.
   - Line feeds should be UNIX-like (`\n`).
-  - All .java source files should be pure ASCII. All .properties files should be ISO-8859-1.
+  - All `.java` source files should be pure ASCII. All `.properties` files should be ISO-8859-1.
   - Number autoboxing and/or autounboxing is forbidden.
-  - Every class should define a constructor, even if it is the default one, and include a call to `super()`.
-  - Every non-nullable argument in a public method should be first validated with a `Validate.notNull(...)` call.
-  - All method arguments should include the `final` modifier, so that their value is never changed.
-  - Include `/* ... */` comments for every algorithm you develop with a minimum of complexity. *"Minimum
-    of complexity"* usually means you had to take some design decisions in order to write it the way you did. Do
-    not write obvious comments.
-  - All public methods and classes directly available to users (i.e. public) should have comprehensive javadoc.
+  - Every class should define a constructor, even if it is the no-argument constructor, and include a call to `super()`.
+  - All method parameters should be declared as `final` so that they cannot be changed or reassigned in the method.
+  - All non-nullable parameters in a public method should be first validated with a `Validate.notNull(...)` call.
+    This maintains consistency in the behavior of public methods and the error message used.  
+  - Include a block comment (`/* ... */`) for any non-trivial algorithm you develop. *"Non-trivial"* usually means you
+    had to make some design decisions to do things in a certain way. Your comment should explain *why* you wrote the
+    code the way you wrote it. Do not write obvious comments that explain what the code does; the code should be clear
+    and expressive enough so the *what* and *how* of it is obvious.
+  - All public methods and classes directly available to users should have comprehensive JavaDoc comments.
 
 ### Detailed HTML/XML code quality standards:
 
   - All tags, CSS styles, file names, etc. must be **in English**.
-  - Lower case should be prefered for HTML/XML artifacts. The only exceptions are `DOCTYPE` and `CDATA` clauses.
+  - Lower case should be preferred for HTML/XML artifacts. The only exceptions are `DOCTYPE` and `CDATA` clauses.
   - All HTML code should be XML-valid (i.e. all tags should be closed, attributes surrounded by commas, etc.)
-  - Maximum line size is 120 characters.
+  - Maximum line length is 120 characters.
   - Indentation should be made with 4 spaces, not tabs.
   - Line feeds should be UNIX-like (`\n`).
-  - All .html and .xml source files should be pure ASCII, even if _content-type_ is set to a different encoding.
+  - All `.html` and `.xml` source files should be pure ASCII, even if _content-type_ is set to a different encoding.
   - All XHTML self-closing (minimized) tags should have a space before `/>` (the XHTML standards say so!).
   - All inline scripts must be enclosed inside a commented `<![CDATA[...]]>` block.
 
@@ -100,7 +102,7 @@ Note the following only applies to documentation/articles meant to be published 
   - All documentation artifacts, including articles, must be written **in correct English**.
   - Your name and email will be displayed as *"author"* of any documentation artifacts you create.
   - Topic and text structure must be first discussed and agreed upon with the project members.
-  - Project members may edit and make small changes to your texts --of which you will be informed-- before
+  - Project members may edit and make small changes to your texts&mdash;of which you will be informed&mdash;before
     publishing them.
   - Format and visual styles must adhere to the Thymeleaf website standards, of which you will be informed
     by the project members.
@@ -109,14 +111,14 @@ Note the following only applies to documentation/articles meant to be published 
 Pay special attention to this
 -----------------------------
 
-All Thymeleaf software is distributed under the **Apache License 2.0** open source license, and your contributions
+All Thymeleaf software is distributed under the **Apache License 2.0** open source license; your contributions
 will be licensed in the same way.
 
 If you work for a company which, by the way or place in which your code was written, by your contract terms
 or by the laws in your country, could claim any rights (including but not limited to intellectual or industrial
 property) over your contributed code, you will have to send the project members (either by email from your
 authorised superiors or by signed fax), a statement indicating that your company agrees with the terms
-explained in this page, and that it both authorises your contribution to Thymeleaf and states that will
+explained in this page, and that it both authorises your contribution to Thymeleaf and states that it will
 never claim any kind of rights over it.
 
 
@@ -146,7 +148,7 @@ may cover more than one software project managed by Thymeleaf.
     representatives, including but not limited to electronic mailing lists, source code control systems,
     and issue tracking systems that are managed by, or on behalf of, Thymeleaf for the purpose of discussing
     and improving the Material, but excluding communication that is conspicuously marked or
-    otherwise designated in writing by you as _"Not a Contribution."
+    otherwise designated in writing by you as _"Not a Contribution."_
   * _"Submission Date"_ means the date on which you submit a Contribution to Thymeleaf.
   * _"Effective Date"_ means the date you execute this agreement or the date You first submit a
     Contribution to Thymeleaf, whichever is earlier.

--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -3,69 +3,65 @@ Contributing to Thymeleaf: Terms and Conditions
 
 ------------------------------------------------------------------------------
 
-
-Do you want to contribute your work to thymeleaf? Well, then first and most important: **THANK YOU!** 
-
+Do you want to contribute your work to thymeleaf? Well, then first and most important: **THANK YOU!**
 
 Now, in order to accept your contribution, there are some terms you must expressly agree with, so please
-read them carefully. They might look a bit cumbersome, but they are here just in order to protect 
+read them carefully. They might look a bit cumbersome, but they are here just in order to protect
 you, your contribution, and especially the project's future.
 
 **Important**: submitting any contributions to the Thymeleaf project implies your **full acceptance of these terms**,
-including the *"Thymeleaf Individual Contributor License Agreement"* detailed at the end. 
+including the *"Thymeleaf Individual Contributor License Agreement"* detailed at the end.
+
 
 Who can contribute?
 -------------------
 
-Anyone, with the unique condition that he/she must be a **private individual**, acting in 
+Anyone, with the unique condition that he/she must be a **private individual**, acting in
 his/her own name, and not being endorsed in their contributed work by any company or government.
 
-Note that this condition will not only refer to the ownership of the effort invested in contributing 
-to the project, but also to the fact that *no private or public company will be mentioned as a a part 
-of your contribution on the project's website or code*, including but not limited to web/email addresses 
+Note that this condition will not only refer to the ownership of the effort invested in contributing
+to the project, but also to the fact that *no private or public company will be mentioned as a a part
+of your contribution on the project's website or code*, including but not limited to web/email addresses
 or package names.
 
 
 What is the first step to be taken?
 -----------------------------------
 
-First of all, **talk to the [project members](http://www.thymeleaf.org/team.html)** (an email should do) about 
-your ideas: new features, fixes, documentation... whatever you would like to contribute to the project. Let we 
-discuss the possibilities with you so that we make sure your contribution goes in the right direction and aligns 
-with the project's standards, intentions and roadmap. 
-
+First of all, **talk to the [project members](http://www.thymeleaf.org/team.html)** (an email should do) about
+your ideas: new features, fixes, documentation... whatever you would like to contribute to the project. Let we
+discuss the possibilities with you so that we make sure your contribution goes in the right direction and aligns
+with the project's standards, intentions and roadmap.
 
 
 How will your relation with the Thymeleaf project be?
 -----------------------------------------------------
 
-Your contributions will have the form of GitHub *pull requests*. Note that contributors do not 
-have read+write (or *pull+push*) access to the project repositories, only project *members* do. 
+Your contributions will have the form of GitHub *pull requests*. Note that contributors do not
+have read+write (or *pull+push*) access to the project repositories, only project *members* do.
 
-Also, please understand that *not all pull requests will be accepted and merged into the project's 
+Also, please understand that *not all pull requests will be accepted and merged into the project's
 repositories*. Talking about your planned contributions with the project members before creating pull requests
 will maximize the possibilities of your contributions being accepted.
 
-Once your contribution is approved, you will be listed as a *contributor* at the 
-[Thymeleaf Team page](http://www.thymeleaf.org/team.html). You can opt-out of this if you want. 
-Also, you will be `@author` for any new Java classes that you write and also co-`@author` to any existing classes to 
+Once your contribution is approved, you will be listed as a *contributor* at the
+[Thymeleaf Team page](http://www.thymeleaf.org/team.html). You can opt-out of this if you want.
+Also, you will be `@author` for any new Java classes that you write and also co-`@author` to any existing classes to
 which you make significant changes. You can also opt-out of this if you want.  
-
-
 
 
 About the code you contribute
 -----------------------------
 
 ### General guidelines:
-  
-  - Obviously, **your code must both compile and work correctly**. Also, the addition of any new patches to the 
+
+  - Obviously, **your code must both compile and work correctly**. Also, the addition of any new patches to the
     codebase should not render it unstable in any way.
   - All your code should be easy to read and understand by a human.
   - There should be no compilation warnings at all.
 
 ### Detailed Java code quality standards:
-  
+
   - All your code should compile and run in **Java 6.0**.
   - All comments, names of classes and variables, log messages, etc. must be **in English**.
   - All `.java` files must include the standard Thymeleaf copyright header.
@@ -73,16 +69,16 @@ About the code you contribute
   - Maximum line size is 120 characters.
   - Indentation should be made with 4 spaces, not tabs.
   - Line feeds should be UNIX-like (`\n`).
-  - All .java source files should be pure ASCII. All .properties files should be ISO-8859-1. 
+  - All .java source files should be pure ASCII. All .properties files should be ISO-8859-1.
   - Number autoboxing and/or autounboxing is forbidden.
   - Every class should define a constructor, even if it is the default one, and include a call to `super()`.
   - Every non-nullable argument in a public method should be first validated with a `Validate.notNull(...)` call.
   - All method arguments should include the `final` modifier, so that their value is never changed.
-  - Include `/* ... */` comments for every algorithm you develop with a minimum of complexity. *"Minimum 
-    of complexity"* usually means you had to take some design decisions in order to write it the way you did. Do 
+  - Include `/* ... */` comments for every algorithm you develop with a minimum of complexity. *"Minimum
+    of complexity"* usually means you had to take some design decisions in order to write it the way you did. Do
     not write obvious comments.
   - All public methods and classes directly available to users (i.e. public) should have comprehensive javadoc.
-  
+
 ### Detailed HTML/XML code quality standards:
 
   - All tags, CSS styles, file names, etc. must be **in English**.
@@ -91,10 +87,10 @@ About the code you contribute
   - Maximum line size is 120 characters.
   - Indentation should be made with 4 spaces, not tabs.
   - Line feeds should be UNIX-like (`\n`).
-  - All .html and .xml source files should be pure ASCII, even if _content-type_ is set to a different encoding. 
+  - All .html and .xml source files should be pure ASCII, even if _content-type_ is set to a different encoding.
   - All XHTML self-closing (minimized) tags should have a space before `/>` (the XHTML standards say so!).
   - All inline scripts must be enclosed inside a commented `<![CDATA[...]]>` block.
-  
+
 
 About the documentation/articles you contribute
 -----------------------------------------------
@@ -104,11 +100,10 @@ Note the following only applies to documentation/articles meant to be published 
   - All documentation artifacts, including articles, must be written **in correct English**.
   - Your name and email will be displayed as *"author"* of any documentation artifacts you create.
   - Topic and text structure must be first discussed and agreed upon with the project members.
-  - Project members may edit and make small changes to your texts --of which you will be informed-- before 
+  - Project members may edit and make small changes to your texts --of which you will be informed-- before
     publishing them.
   - Format and visual styles must adhere to the thymeleaf website standards, of which you will be informed
     by the project members.
-
 
 
 Pay special attention to this
@@ -117,22 +112,22 @@ Pay special attention to this
 All Thymeleaf software is distributed under the **Apache License 2.0** open source license, and your contributions
 will be licensed in the same way.
 
-If you work for a company which, by the way or place in which your code was written, by your contract terms 
-or by the laws in your country, could claim any rights (including but not limited to intellectual or industrial 
-property) over your contributed code, you will have to send the project members (either by email from your 
-authorised superiors or by signed fax), a statement indicating that your company agrees with the terms 
-explained in this page, and that it both authorises your contribution to Thymeleaf and states that will 
+If you work for a company which, by the way or place in which your code was written, by your contract terms
+or by the laws in your country, could claim any rights (including but not limited to intellectual or industrial
+property) over your contributed code, you will have to send the project members (either by email from your
+authorised superiors or by signed fax), a statement indicating that your company agrees with the terms
+explained in this page, and that it both authorises your contribution to Thymeleaf and states that will
 never claim any kind of rights over it.
-
 
 
 Thymeleaf Individual Contributor License Agreement
 --------------------------------------------------
 
-This contributor agreement ("Agreement") documents the rights granted by contributors to the Thymeleaf Project. 
+This contributor agreement ("Agreement") documents the rights granted by contributors to the Thymeleaf Project.
 
 This is a legally binding document, so please read it carefully before agreeing to it. The Agreement
 may cover more than one software project managed by Thymeleaf.
+
 
 ###1. Definitions
 
@@ -155,7 +150,8 @@ may cover more than one software project managed by Thymeleaf.
   * _"Submission Date"_ means the date on which you submit a Contribution to Thymeleaf.
   * _"Effective Date"_ means the date you execute this agreement or the date You first submit a
     Contribution to Thymeleaf, whichever is earlier.
-  
+
+
 ###2. Grant of Rights
 
 ####2.1. Copyright License
@@ -179,22 +175,19 @@ portions of such combination). This license is granted only to the extent that t
 licensed rights infringes such patent claims; and provided that this license is conditioned upon
 compliance with Section 2.3.
 
-
 ####2.3 Outbound License
 
 As a condition on the grant of rights in Sections 2.1 and 2.2, Thymeleaf agrees to license the Contribution only
-under the terms of the Apache License 2.0 (including any right to adopt any future version of this license if 
+under the terms of the Apache License 2.0 (including any right to adopt any future version of this license if
 permitted).
 
+####2.4 Moral Rights
 
-####2.4 Moral Rights 
-
-If moral rights apply to the Contribution, to the maximum extent permitted by law, you waive and agree not 
-to assert such moral rights against Thymeleaf or its successors in interest, or any of our licensees, either 
+If moral rights apply to the Contribution, to the maximum extent permitted by law, you waive and agree not
+to assert such moral rights against Thymeleaf or its successors in interest, or any of our licensees, either
 direct or indirect.
 
-
-####2.5 Thymeleaf Rights 
+####2.5 Thymeleaf Rights
 
 You acknowledge that Thymeleaf is not obligated to use your Contribution as part of the
 Material and may decide to include any Contributions Thymeleaf considers appropriate.
@@ -202,7 +195,6 @@ Material and may decide to include any Contributions Thymeleaf considers appropr
 ####2.6 Reservation of Rights
 
 Any rights not expressly assigned or licensed under this section are expressly reserved by you.
-
 
 
 ###3. Agreement
@@ -214,28 +206,25 @@ You confirm that:
         the rights under Section 2.
   * (c) The grant of rights under Section 2 does not violate any grant of rights which you have made to
         third parties, including your employer. If you are an employee, you have had your employer approve
-        this Agreement. If you are less than eighteen years old, please have your parents or guardian 
+        this Agreement. If you are less than eighteen years old, please have your parents or guardian
         sign the Agreement.
-
 
 
 ###4. Disclaimer
 
-EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS PROVIDED "AS IS". MORE PARTICULARLY, 
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS PROVIDED "AS IS". MORE PARTICULARLY,
 ALL EXPRESS OR IMPLIED WARRANTIES INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE EXPRESSLY DISCLAIMED BY YOU TO THYMELEAF AND BY
-THYMELEAF TO YOU. TO THE EXTENT THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY IS LIMITED IN 
+THYMELEAF TO YOU. TO THE EXTENT THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY IS LIMITED IN
 DURATION TO THE MINIMUM PERIOD PERMITTED BY LAW.
-
 
 
 ###5. Consequential Damage Waiver
 
-TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU OR THYMELEAF BE LIABLE FOR ANY LOSS OF 
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU OR THYMELEAF BE LIABLE FOR ANY LOSS OF
 PROFITS, LOSS OF ANTICIPATED SAVINGS, LOSS OF DATA, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL AND EXEMPLARY
-DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR OTHERWISE) 
+DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR OTHERWISE)
 UPON WHICH THE CLAIM IS BASED.
-
 
 
 ###6. Miscellaneous
@@ -259,6 +248,3 @@ UPON WHICH THE CLAIM IS BASED.
         provision and which is enforceable. The terms and conditions set forth in this Agreement shall apply
         notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the
         maximum extent possible under law.
-
-
-


### PR DESCRIPTION
These are edits to the individual contributor terms and agreement to improve the verbiage, correct misspellings, capitalization, and typos, and the change to the coding standard around the use of "parameter" instead of "argument" and comments for non-trivial algorithms.