### PR TITLE
Fixes #595 - Use {@value} in Javadoc to ensure constant values match …

### DIFF
--- a/src/main/java/org/thymeleaf/cache/StandardCacheManager.java
+++ b/src/main/java/org/thymeleaf/cache/StandardCacheManager.java
@@ -72,27 +72,27 @@ public class StandardCacheManager extends AbstractCacheManager {
 
     
     /**
-     * Default template cache name: {@value DEFAULT_TEMPLATE_CACHE_NAME}
+     * Default template cache name: {@value}
      */
     public static final String DEFAULT_TEMPLATE_CACHE_NAME = "TEMPLATE_CACHE";
     
     /**
-     * Default template cache initial size: {@value DEFAULT_TEMPLATE_CACHE_INITIAL_SIZE}
+     * Default template cache initial size: {@value}
      */
     public static final int DEFAULT_TEMPLATE_CACHE_INITIAL_SIZE = 20;
     
     /**
-     * Default template cache maximum size: {@value DEFAULT_TEMPLATE_CACHE_MAX_SIZE}
+     * Default template cache maximum size: {@value}
      */
     public static final int DEFAULT_TEMPLATE_CACHE_MAX_SIZE = 200;
 
     /**
-     * Default template cache "enable counters" flag: {@value DEFAULT_TEMPLATE_CACHE_ENABLE_COUNTERS}
+     * Default template cache "enable counters" flag: {@value}
      */
     public static final boolean DEFAULT_TEMPLATE_CACHE_ENABLE_COUNTERS = false;
 
     /**
-     * Default template cache "use soft references" flag: {@value DEFAULT_TEMPLATE_CACHE_USE_SOFT_REFERENCES}
+     * Default template cache "use soft references" flag: {@value}
      */
     public static final boolean DEFAULT_TEMPLATE_CACHE_USE_SOFT_REFERENCES = true;
     
@@ -108,27 +108,27 @@ public class StandardCacheManager extends AbstractCacheManager {
 
     
     /**
-     * Default expression cache name: {@value DEFAULT_EXPRESSION_CACHE_NAME}
+     * Default expression cache name: {@value}
      */
     public static final String DEFAULT_EXPRESSION_CACHE_NAME = "EXPRESSION_CACHE";
     
     /**
-     * Default expression cache initial size: {@value DEFAULT_EXPRESSION_CACHE_INITIAL_SIZE}
+     * Default expression cache initial size: {@value}
      */
     public static final int DEFAULT_EXPRESSION_CACHE_INITIAL_SIZE = 100;
     
     /**
-     * Default expression cache maximum size: {@value DEFAULT_EXPRESSION_CACHE_MAX_SIZE}
+     * Default expression cache maximum size: {@value}
      */
     public static final int DEFAULT_EXPRESSION_CACHE_MAX_SIZE = 500;
 
     /**
-     * Default expression cache "enable counters" flag: {@value DEFAULT_EXPRESSION_CACHE_ENABLE_COUNTERS}
+     * Default expression cache "enable counters" flag: {@value}
      */
     public static final boolean DEFAULT_EXPRESSION_CACHE_ENABLE_COUNTERS = false;
 
     /**
-     * Default expression cache "use soft references" flag: {@value DEFAULT_EXPRESSION_CACHE_USE_SOFT_REFERENCES}
+     * Default expression cache "use soft references" flag: {@value}
      */
     public static final boolean DEFAULT_EXPRESSION_CACHE_USE_SOFT_REFERENCES = true;
     

--- a/src/main/java/org/thymeleaf/cache/StandardCacheManager.java
+++ b/src/main/java/org/thymeleaf/cache/StandardCacheManager.java
@@ -72,27 +72,27 @@ public class StandardCacheManager extends AbstractCacheManager {
 
     
     /**
-     * Default template cache name: "TEMPLATE_CACHE"
+     * Default template cache name: {@value DEFAULT_TEMPLATE_CACHE_NAME}
      */
     public static final String DEFAULT_TEMPLATE_CACHE_NAME = "TEMPLATE_CACHE";
     
     /**
-     * Default template cache initial size: 10
+     * Default template cache initial size: {@value DEFAULT_TEMPLATE_CACHE_INITIAL_SIZE}
      */
     public static final int DEFAULT_TEMPLATE_CACHE_INITIAL_SIZE = 20;
     
     /**
-     * Default template cache maximum size: 50
+     * Default template cache maximum size: {@value DEFAULT_TEMPLATE_CACHE_MAX_SIZE}
      */
     public static final int DEFAULT_TEMPLATE_CACHE_MAX_SIZE = 200;
 
     /**
-     * Default template cache "enable counters" flag: false
+     * Default template cache "enable counters" flag: {@value DEFAULT_TEMPLATE_CACHE_ENABLE_COUNTERS}
      */
     public static final boolean DEFAULT_TEMPLATE_CACHE_ENABLE_COUNTERS = false;
 
     /**
-     * Default template cache "use soft references" flag: true
+     * Default template cache "use soft references" flag: {@value DEFAULT_TEMPLATE_CACHE_USE_SOFT_REFERENCES}
      */
     public static final boolean DEFAULT_TEMPLATE_CACHE_USE_SOFT_REFERENCES = true;
     
@@ -108,27 +108,27 @@ public class StandardCacheManager extends AbstractCacheManager {
 
     
     /**
-     * Default expression cache name: "EXPRESSION_CACHE"
+     * Default expression cache name: {@value DEFAULT_EXPRESSION_CACHE_NAME}
      */
     public static final String DEFAULT_EXPRESSION_CACHE_NAME = "EXPRESSION_CACHE";
     
     /**
-     * Default expression cache initial size: 100
+     * Default expression cache initial size: {@value DEFAULT_EXPRESSION_CACHE_INITIAL_SIZE}
      */
     public static final int DEFAULT_EXPRESSION_CACHE_INITIAL_SIZE = 100;
     
     /**
-     * Default expression cache maximum size: 500
+     * Default expression cache maximum size: {@value DEFAULT_EXPRESSION_CACHE_MAX_SIZE}
      */
     public static final int DEFAULT_EXPRESSION_CACHE_MAX_SIZE = 500;
 
     /**
-     * Default expression cache "enable counters" flag: false
+     * Default expression cache "enable counters" flag: {@value DEFAULT_EXPRESSION_CACHE_ENABLE_COUNTERS}
      */
     public static final boolean DEFAULT_EXPRESSION_CACHE_ENABLE_COUNTERS = false;
 
     /**
-     * Default expression cache "use soft references" flag: true
+     * Default expression cache "use soft references" flag: {@value DEFAULT_EXPRESSION_CACHE_USE_SOFT_REFERENCES}
      */
     public static final boolean DEFAULT_EXPRESSION_CACHE_USE_SOFT_REFERENCES = true;
     

--- a/src/main/java/org/thymeleaf/templateparser/markup/decoupled/StandardDecoupledTemplateLogicResolver.java
+++ b/src/main/java/org/thymeleaf/templateparser/markup/decoupled/StandardDecoupledTemplateLogicResolver.java
@@ -58,7 +58,7 @@ public final class StandardDecoupledTemplateLogicResolver implements IDecoupledT
 
     /**
      * <p>
-     *   Default suffix applied to the relative resources resolved: <tt>.th.xml</tt>
+     *   Default suffix applied to the relative resources resolved: {@value DECOUPLED_TEMPLATE_LOGIC_FILE_SUFFIX}
      * </p>
      */
     public static final String DECOUPLED_TEMPLATE_LOGIC_FILE_SUFFIX = ".th.xml";

--- a/src/main/java/org/thymeleaf/templateparser/markup/decoupled/StandardDecoupledTemplateLogicResolver.java
+++ b/src/main/java/org/thymeleaf/templateparser/markup/decoupled/StandardDecoupledTemplateLogicResolver.java
@@ -19,11 +19,11 @@
  */
 package org.thymeleaf.templateparser.markup.decoupled;
 
-import java.util.Set;
-
 import org.thymeleaf.IEngineConfiguration;
 import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresource.ITemplateResource;
+
+import java.util.Set;
 
 /**
  * <p>
@@ -58,7 +58,7 @@ public final class StandardDecoupledTemplateLogicResolver implements IDecoupledT
 
     /**
      * <p>
-     *   Default suffix applied to the relative resources resolved: {@value DECOUPLED_TEMPLATE_LOGIC_FILE_SUFFIX}
+     *   Default suffix applied to the relative resources resolved: {@value}
      * </p>
      */
     public static final String DECOUPLED_TEMPLATE_LOGIC_FILE_SUFFIX = ".th.xml";

--- a/src/main/java/org/thymeleaf/templateresolver/AbstractConfigurableTemplateResolver.java
+++ b/src/main/java/org/thymeleaf/templateresolver/AbstractConfigurableTemplateResolver.java
@@ -19,11 +19,6 @@
  */
 package org.thymeleaf.templateresolver;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import org.thymeleaf.IEngineConfiguration;
 import org.thymeleaf.cache.AlwaysValidCacheEntryValidity;
 import org.thymeleaf.cache.ICacheEntryValidity;
@@ -34,6 +29,11 @@ import org.thymeleaf.templateresource.ITemplateResource;
 import org.thymeleaf.util.PatternSpec;
 import org.thymeleaf.util.StringUtils;
 import org.thymeleaf.util.Validate;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -69,7 +69,7 @@ public abstract class AbstractConfigurableTemplateResolver extends AbstractTempl
 
     /**
      * <p>
-     *   Default value for the <i>cacheable</i> flag: {@value DEFAULT_CACHEABLE}.
+     *   Default value for the <i>cacheable</i> flag: {@value}.
      * </p>
      */
     public static final boolean DEFAULT_CACHEABLE = true;

--- a/src/main/java/org/thymeleaf/templateresolver/AbstractConfigurableTemplateResolver.java
+++ b/src/main/java/org/thymeleaf/templateresolver/AbstractConfigurableTemplateResolver.java
@@ -69,7 +69,7 @@ public abstract class AbstractConfigurableTemplateResolver extends AbstractTempl
 
     /**
      * <p>
-     *   Default value for the <i>cacheable</i> flag: true.
+     *   Default value for the <i>cacheable</i> flag: {@value DEFAULT_CACHEABLE}.
      * </p>
      */
     public static final boolean DEFAULT_CACHEABLE = true;

--- a/src/main/java/org/thymeleaf/templateresolver/StringTemplateResolver.java
+++ b/src/main/java/org/thymeleaf/templateresolver/StringTemplateResolver.java
@@ -70,7 +70,7 @@ public class StringTemplateResolver extends AbstractTemplateResolver {
 
     /**
      * <p>
-     *   Default value for the <i>cacheable</i> flag: false.
+     *   Default value for the <i>cacheable</i> flag: {@value DEFAULT_CACHEABLE}
      * </p>
      */
     public static final boolean DEFAULT_CACHEABLE = false;

--- a/src/main/java/org/thymeleaf/templateresolver/StringTemplateResolver.java
+++ b/src/main/java/org/thymeleaf/templateresolver/StringTemplateResolver.java
@@ -19,8 +19,6 @@
  */
 package org.thymeleaf.templateresolver;
 
-import java.util.Map;
-
 import org.thymeleaf.IEngineConfiguration;
 import org.thymeleaf.cache.AlwaysValidCacheEntryValidity;
 import org.thymeleaf.cache.ICacheEntryValidity;
@@ -31,6 +29,8 @@ import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresource.ITemplateResource;
 import org.thymeleaf.templateresource.StringTemplateResource;
 import org.thymeleaf.util.Validate;
+
+import java.util.Map;
 
 /**
  * <p>
@@ -70,7 +70,7 @@ public class StringTemplateResolver extends AbstractTemplateResolver {
 
     /**
      * <p>
-     *   Default value for the <i>cacheable</i> flag: {@value DEFAULT_CACHEABLE}
+     *   Default value for the <i>cacheable</i> flag: {@value}
      * </p>
      */
     public static final boolean DEFAULT_CACHEABLE = false;


### PR DESCRIPTION
…documentation.