### PR TITLE
Fix WebEngineContext application/session isEmpty()

### DIFF
--- a/src/main/java/org/thymeleaf/context/WebEngineContext.java
+++ b/src/main/java/org/thymeleaf/context/WebEngineContext.java
@@ -386,7 +386,7 @@ public class WebEngineContext extends AbstractEngineContext implements IEngineCo
                 return true;
             }
             final Enumeration<String> attributeNames = this.session.getAttributeNames();
-            return attributeNames.hasMoreElements();
+            return !attributeNames.hasMoreElements();
         }
 
         @Override
@@ -483,7 +483,7 @@ public class WebEngineContext extends AbstractEngineContext implements IEngineCo
         @Override
         public boolean isEmpty() {
             final Enumeration<String> attributeNames = this.servletContext.getAttributeNames();
-            return attributeNames.hasMoreElements();
+            return !attributeNames.hasMoreElements();
         }
 
         @Override


### PR DESCRIPTION
`Enumeration.hasMoreElements()` is logically the opposite of `Collection.isEmpty()` (when used as in `ServletContextAttributesMap.isEmpty()` and `SessionAttributesMap.isEmpty()`) and should be inverted before being returned.