### PR TITLE
Fix #646 - Fix calculation hit ratio in StandardCache's cache report.

### DIFF
--- a/src/main/java/org/thymeleaf/cache/StandardCache.java
+++ b/src/main/java/org/thymeleaf/cache/StandardCache.java
@@ -306,7 +306,7 @@ public final class StandardCache<K, V> implements ICache<K,V> {
             return 0;
         }
 
-        return hitCount / getCount;
+        return (double) hitCount / (double) getCount;
     }
 
     public double getMissRatio() {
@@ -336,7 +336,7 @@ public final class StandardCache<K, V> implements ICache<K,V> {
                     long putCount = getPutCount();
                     long getCount = getGetCount();
 
-                    double hitRatio = hitCount / getCount;
+                    double hitRatio = (double) hitCount / (double) getCount;
                     double missRatio = 1 - hitRatio;
 
                     this.logger.trace(


### PR DESCRIPTION
#646 fixed.

Please check it, Thanks.