### PR TITLE
moves up null check on key parameter

### DIFF
--- a/src/main/java/org/thymeleaf/cache/StandardCache.java
+++ b/src/main/java/org/thymeleaf/cache/StandardCache.java
@@ -480,10 +480,13 @@ public final class StandardCache<K, V> implements ICache<K,V> {
 
 
         private int removeWithoutTracing(final K key) {
+            if (key == null) {
+                return -1;
+            }
             // FIFO is also updated to avoid 'removed' keys remaining at FIFO (which could end up reducing cache size to 1)
             final CacheEntry<V> removed = this.container.remove(key);
             if (removed != null) {
-                if (this.sizeLimit && key != null) {
+                if (this.sizeLimit) {
                     for (int i = 0; i < this.maxSize; i++) {
                         if (key.equals(this.fifo[i])) {
                             this.fifo[i] = null;
@@ -497,13 +500,16 @@ public final class StandardCache<K, V> implements ICache<K,V> {
 
 
         private synchronized int removeWithTracing(final K key) {
+            if (key == null) {
+                return -1;
+            }
             // FIFO is also updated to avoid 'removed' keys remaining at FIFO (which could end up reducing cache size to 1)
             final CacheEntry<V> removed = this.container.remove(key);
             if (removed == null) {
                 // When tracing is active, this means nothing was removed
                 return -1;
             }
-            if (this.sizeLimit && key != null) {
+            if (this.sizeLimit) {
                 for (int i = 0; i < this.maxSize; i++) {
                     if (key.equals(this.fifo[i])) {
                         this.fifo[i] = null;


### PR DESCRIPTION
This moves the nullcheck on key up so it is checked before the value is accesed. Avoids sonar issues etc.