### PR TITLE
Added inputStream method to ITemplateResource

### DIFF
--- a/src/main/java/org/thymeleaf/templateresource/ClassLoaderTemplateResource.java
+++ b/src/main/java/org/thymeleaf/templateresource/ClassLoaderTemplateResource.java
@@ -42,7 +42,7 @@ import org.thymeleaf.util.Validate;
  *
  * @author Daniel Fern&aacute;ndez
  * @since 3.0.0
- * 
+ *
  */
 public final class ClassLoaderTemplateResource implements ITemplateResource {
 
@@ -119,6 +119,20 @@ public final class ClassLoaderTemplateResource implements ITemplateResource {
 
     public Reader reader() throws IOException {
 
+        final InputStream inputStream = inputStream();
+
+        if (!StringUtils.isEmptyOrWhitespace(this.characterEncoding)) {
+            return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream), this.characterEncoding));
+        }
+
+        return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream)));
+
+    }
+
+
+
+
+    public InputStream inputStream() throws IOException {
         final InputStream inputStream;
         if (this.optionalClassLoader != null) {
             inputStream = this.optionalClassLoader.getResourceAsStream(this.path);
@@ -129,13 +143,7 @@ public final class ClassLoaderTemplateResource implements ITemplateResource {
         if (inputStream == null) {
             throw new FileNotFoundException(String.format("ClassLoader resource \"%s\" could not be resolved", this.path));
         }
-
-        if (!StringUtils.isEmptyOrWhitespace(this.characterEncoding)) {
-            return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream), this.characterEncoding));
-        }
-
-        return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream)));
-
+        return inputStream;
     }
 
 

--- a/src/main/java/org/thymeleaf/templateresource/FileTemplateResource.java
+++ b/src/main/java/org/thymeleaf/templateresource/FileTemplateResource.java
@@ -42,7 +42,7 @@ import org.thymeleaf.util.Validate;
  *
  * @author Daniel Fern&aacute;ndez
  * @since 3.0.0
- * 
+ *
  */
 public final class FileTemplateResource implements ITemplateResource, Serializable {
 
@@ -99,7 +99,7 @@ public final class FileTemplateResource implements ITemplateResource, Serializab
 
     public Reader reader() throws IOException {
 
-        final InputStream inputStream = new FileInputStream(this.file);
+        final InputStream inputStream = inputStream();
 
         if (!StringUtils.isEmptyOrWhitespace(this.characterEncoding)) {
             return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream), this.characterEncoding));
@@ -107,6 +107,13 @@ public final class FileTemplateResource implements ITemplateResource, Serializab
 
         return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream)));
 
+    }
+
+
+
+
+    public InputStream inputStream() throws IOException {
+        return new FileInputStream(this.file);
     }
 
 

--- a/src/main/java/org/thymeleaf/templateresource/ITemplateResource.java
+++ b/src/main/java/org/thymeleaf/templateresource/ITemplateResource.java
@@ -20,6 +20,7 @@
 package org.thymeleaf.templateresource;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 
 /**
@@ -58,7 +59,7 @@ import java.io.Reader;
  * @see UrlTemplateResource
  *
  * @since 3.0.0
- * 
+ *
  */
 public interface ITemplateResource {
 
@@ -135,6 +136,19 @@ public interface ITemplateResource {
      */
     public Reader reader() throws IOException;
 
+    /**
+     * <p>
+     *   Returns an {@link InputStream} that can be used for consuming the template contents as binary data.
+     * </p>
+     * <p>
+     *   Note this InputStream should be closed after being fully consumed, just like any other resources.
+     * </p>
+     *
+     * @return an {@link InputStream} on the template contents. Should never return {@code null}.
+     * @throws IOException if an input/output exception happens or if the resource does not exist (e.g.
+     *                     {@link java.io.FileNotFoundException}).
+     */
+    public InputStream inputStream() throws IOException;
 
     /**
      * <p>

--- a/src/main/java/org/thymeleaf/templateresource/ServletContextTemplateResource.java
+++ b/src/main/java/org/thymeleaf/templateresource/ServletContextTemplateResource.java
@@ -45,7 +45,7 @@ import org.thymeleaf.util.Validate;
  *
  * @author Daniel Fern&aacute;ndez
  * @since 3.0.0
- * 
+ *
  */
 public final class ServletContextTemplateResource implements ITemplateResource {
 
@@ -90,10 +90,7 @@ public final class ServletContextTemplateResource implements ITemplateResource {
 
     public Reader reader() throws IOException {
 
-        final InputStream inputStream = this.servletContext.getResourceAsStream(this.path);
-        if (inputStream == null) {
-            throw new FileNotFoundException(String.format("ServletContext resource \"%s\" does not exist", this.path));
-        }
+        final InputStream inputStream = inputStream();
 
         if (!StringUtils.isEmptyOrWhitespace(this.characterEncoding)) {
             return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream), this.characterEncoding));
@@ -101,6 +98,17 @@ public final class ServletContextTemplateResource implements ITemplateResource {
 
         return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream)));
 
+    }
+
+
+
+
+    public InputStream inputStream() throws IOException {
+        InputStream inputStream = this.servletContext.getResourceAsStream(this.path);
+        if (inputStream == null) {
+            throw new FileNotFoundException(String.format("ServletContext resource \"%s\" does not exist", this.path));
+        }
+        return inputStream;
     }
 
 

--- a/src/main/java/org/thymeleaf/templateresource/StringTemplateResource.java
+++ b/src/main/java/org/thymeleaf/templateresource/StringTemplateResource.java
@@ -19,7 +19,9 @@
  */
 package org.thymeleaf.templateresource;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 
@@ -37,7 +39,7 @@ import org.thymeleaf.util.Validate;
  *
  * @author Daniel Fern&aacute;ndez
  * @since 3.0.0
- * 
+ *
  */
 public final class StringTemplateResource implements ITemplateResource {
 
@@ -73,6 +75,13 @@ public final class StringTemplateResource implements ITemplateResource {
 
     public Reader reader() throws IOException {
         return new StringReader(this.resource);
+    }
+
+
+
+
+    public InputStream inputStream() throws IOException {
+        return new ByteArrayInputStream(this.resource.getBytes("UTF-8"));
     }
 
 

--- a/src/main/java/org/thymeleaf/templateresource/UrlTemplateResource.java
+++ b/src/main/java/org/thymeleaf/templateresource/UrlTemplateResource.java
@@ -48,7 +48,7 @@ import org.thymeleaf.util.Validate;
  *
  * @author Daniel Fern&aacute;ndez
  * @since 3.0.0
- * 
+ *
  */
 public final class UrlTemplateResource implements ITemplateResource, Serializable {
 
@@ -115,7 +115,7 @@ public final class UrlTemplateResource implements ITemplateResource, Serializabl
 
 
 
-    private InputStream inputStream() throws IOException {
+    public InputStream inputStream() throws IOException {
 
         final URLConnection connection = this.url.openConnection();
         if (connection.getClass().getSimpleName().startsWith("JNLP")) {


### PR DESCRIPTION
The main reason for adding this is our usecase of using thymeleaf for e-mail templates.

To refer to images and other binary resources, I created an extension tag processor that reads the resource, adds it to a special container in a context, and outputs a "cid:unique-code" url to refer to the image. However I need to be able to load the resource as binary data, and ITemplateResource only has a `reader` method. I added an `inputStream` method to ITemplateResource and all its implementations in the thymeleaf and thymeleaf-spring repositories. I added a unit test so that this method has the same amount of testing as the `reader` method. 

(Since the `reader` methods were all changes to use the `inputStream` method to avoid code duplication, the ability to load a resource at all also means that the`inputStream()` method worked, so it's implicitly tested in many more cases, just as the `reader` method is)

This pull request has accompanying pull requests in thymeleaf-tests and thymeleaf-spring repositories.