### PR TITLE
javadoc error example

### DIFF
--- a/src/main/java/org/thymeleaf/TemplateEngine.java
+++ b/src/main/java/org/thymeleaf/TemplateEngine.java
@@ -176,7 +176,7 @@ import org.thymeleaf.util.Validate;
  *   {@link javax.servlet.ServletContext} objects as constructor arguments: 
  * </p>
  * <code>
- *   final IContext ctx = new WebContext(request, response, servletContext);<br>
+ *   final WebContext ctx = new WebContext(request, response, servletContext);<br>
  *   ctx.setVariable("allItems", items);
  * </code>
  * <p>


### PR DESCRIPTION
the interface IWebContext have not the method setVariable() ,so the type of the instance variables ctx  should IWebContext or AbstractContext