### PR TITLE
Create artifact compatible with Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,24 @@
         <version>2.5.3</version>
       </plugin>
 
+      <!-- Create Jakarta EE 9 version of artifact -->
+      <plugin>
+        <groupId>org.eclipse.transformer</groupId>
+        <artifactId>org.eclipse.transformer.maven</artifactId>
+        <version>0.2.0</version>
+        <configuration>
+          <classifier>jakarta</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- IMPORTANT: This plugin should always appear AFTER maven-release-plugin in this pom.xml -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The Servlet specification had to migrate the `javax.servlet` package names to `jakarta.servlet` with the 5.0 release for legal reasons. Thymeleaf currently compiles against Servlet 2.5 and therefore is not compatible with Servlet 5.0 and servlet containers implementing it (like Apache Tomcat 10). Please refer to #811 for more details.

To allow users to use Thymeleaf with Servlet 5.0 / Jakarta EE 9 with minimal impact for the Thymeleaf project, this PR adds the [Eclipse Transformer](https://projects.eclipse.org/projects/technology.transformer) Maven Plugin to the `pom.xml`. Basically this plugin mutates class files by rewriting `javax.servlet` references to `jakarta.servlet`, puts the mutated classes into a separate artifact with a classifier of `jakarta` and attaches it to the build lifecycle. This means that a second artifact for Jakarta EE 9 will be built along with the standard artifact.

So to use Thymeleaf with Servlet 5, you just have to adjust your dependency and add the `jakarta` classifier:

```xml
<dependency>
    <groupId>org.thymeleaf</groupId>
    <artifactId>thymeleaf</artifactId>
    <version>3.0.13-SNAPSHOT</version>
    <classifier>jakarta</classifier>
</dependency>
```

I already tested the corresponding artifact and was able to integrate Thymeleaf as a view engine into the Jakarta MVC implementation Eclipse Krazo with minimal effort.

I think this approach is a great way to add support for the latest Servlet specification with minimal impact for the project.

Let me know what you think!