### PR TITLE
Add Jakarta EE Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
   </distributionManagement>
 
   <properties>
-    <java.version>6</java.version>
+    <java.version>8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.release>${java.version}</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
     <!-- valid approach for project names containing hyphens, which are not allowed in module names. -->
     <module.name>thymeleaf</module.name>
     <servlet-api.version>2.5</servlet-api.version>
+    <jakarta-servlet-api.version>5.0.0</jakarta-servlet-api.version>
     <ognl.version>3.1.26</ognl.version>
     <attoparser.version>2.0.5.RELEASE</attoparser.version>
     <unbescape.version>1.1.6.RELEASE</unbescape.version>
@@ -309,6 +310,14 @@
 
 
   <dependencies>
+
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta-servlet-api.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <groupId>org.thymeleaf</groupId>
   <artifactId>thymeleaf</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.15-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <name>thymeleaf</name>
   <url>http://www.thymeleaf.org</url>
 

--- a/src/main/java/org/thymeleaf/context/IJakartaWebContext.java
+++ b/src/main/java/org/thymeleaf/context/IJakartaWebContext.java
@@ -1,0 +1,85 @@
+/*
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2018, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * =============================================================================
+ */
+package org.thymeleaf.context;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * <p>
+ *   Specialization of the {@link IContext} interface to be implemented by contexts used for template
+ *   processing in web environments.
+ * </p>
+ * <p>
+ *   Objects implementing this interface add to the usual {@link IContext} data the Servlet-API-related
+ *   artifacts needed to perform web-oriented functions such as URL rewriting or request/session access.
+ * </p>
+ * <p>
+ *   Note a class with this name existed since 1.0, but it was completely reimplemented
+ *   in Thymeleaf 3.0
+ * </p>
+ *
+ * @author Daniel Fern&aacute;ndez
+ *
+ * @since 3.0.0
+ *
+ */
+public interface IJakartaWebContext extends IContext {
+
+    /**
+     * <p>
+     *   Returns the {@link HttpServletRequest} object associated with the template execution.
+     * </p>
+     *
+     * @return the request object.
+     */
+    public HttpServletRequest getRequest();
+
+    /**
+     * <p>
+     *   Returns the {@link HttpServletResponse} object associated with the template execution.
+     * </p>
+     *
+     * @return the response object.
+     */
+    public HttpServletResponse getResponse();
+
+    /**
+     * <p>
+     *   Returns the {@link HttpSession} object associated with the template execution, or null if
+     *   there is no session.
+     * </p>
+     *
+     * @return the session object. Might be null if no session has been created.
+     */
+    public HttpSession getSession();
+
+    /**
+     * <p>
+     *   Returns the {@link ServletContext} object associated with the template execution.
+     * </p>
+     *
+     * @return the servlet context object.
+     */
+    public ServletContext getServletContext();
+
+}

--- a/src/main/java/org/thymeleaf/context/JakartaWebContext.java
+++ b/src/main/java/org/thymeleaf/context/JakartaWebContext.java
@@ -1,0 +1,96 @@
+/*
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2018, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * =============================================================================
+ */
+package org.thymeleaf.context;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * <p>
+ *   Basic web-oriented implementation of the {@link IContext} and {@link IWebContext} interfaces.
+ * </p>
+ * <p>
+ *   This context implementation contains all the required Servlet-API artifacts needed for template
+ *   execution in web environments, and should be enough for most web-based scenarios of template
+ *   processing.
+ * </p>
+ * <p>
+ *   Note a class with this name existed since 2.0.9, but it was completely reimplemented
+ *   in Thymeleaf 3.0
+ * </p>
+ *
+ * @author Daniel Fern&aacute;ndez
+ *
+ * @since 3.0.0
+ *
+ */
+public final class JakartaWebContext extends AbstractContext implements IJakartaWebContext {
+
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+    private final ServletContext servletContext;
+
+
+    public JakartaWebContext(final HttpServletRequest request, final HttpServletResponse response,
+							 final ServletContext servletContext) {
+        super();
+        this.request = request;
+        this.response = response;
+        this.servletContext = servletContext;
+    }
+
+    public JakartaWebContext(final HttpServletRequest request, final HttpServletResponse response,
+							 final ServletContext servletContext, final Locale locale) {
+        super(locale);
+        this.request = request;
+        this.response = response;
+        this.servletContext = servletContext;
+    }
+
+    public JakartaWebContext(final HttpServletRequest request, final HttpServletResponse response,
+							 final ServletContext servletContext, final Locale locale, final Map<String, Object> variables) {
+        super(locale, variables);
+        this.request = request;
+        this.response = response;
+        this.servletContext = servletContext;
+    }
+
+
+    public HttpServletRequest getRequest() {
+        return this.request;
+    }
+
+    public HttpSession getSession() {
+        return this.request.getSession(false);
+    }
+
+    public HttpServletResponse getResponse() {
+        return this.response;
+    }
+
+    public ServletContext getServletContext() {
+        return this.servletContext;
+    }
+
+}

--- a/src/main/java/org/thymeleaf/context/JakartaWebEngineContext.java
+++ b/src/main/java/org/thymeleaf/context/JakartaWebEngineContext.java
@@ -1,0 +1,1398 @@
+/*
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2018, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * =============================================================================
+ */
+package org.thymeleaf.context;
+
+import org.thymeleaf.IEngineConfiguration;
+import org.thymeleaf.engine.TemplateData;
+import org.thymeleaf.inline.IInliner;
+import org.thymeleaf.inline.NoOpInliner;
+import org.thymeleaf.model.IProcessableElementTag;
+import org.thymeleaf.util.Validate;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.lang.reflect.Array;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * <p>
+ *   Basic <b>web</b> implementation of the {@link IEngineContext} interface, based on the Servlet API.
+ * </p>
+ * <p>
+ *   This is the context implementation that will be used by default for web processing. Note that <b>this is an
+ *   internal implementation, and there is no reason for users' code to directly reference or use it instead
+ *   of its implemented interfaces</b>.
+ * </p>
+ * <p>
+ *   This class is NOT thread-safe. Thread-safety is not a requirement for context implementations.
+ * </p>
+ *
+ * @author Daniel Fern&aacute;ndez
+ *
+ * @since 3.0.0
+ *
+ */
+public class JakartaWebEngineContext extends AbstractEngineContext implements IEngineContext, IJakartaWebContext {
+
+    /*
+     * ---------------------------------------------------------------------------
+     * THIS MAP FORWARDS ALL OPERATIONS TO THE UNDERLYING REQUEST, EXCEPT
+     * FOR THE param (request parameters), session (session attributes) AND
+     * application (servlet context attributes) VARIABLES.
+     *
+     * NOTE that, even if attributes are leveled so that above level 0 they are
+     * considered local and thus disappear after lowering the level, attributes
+     * directly set on the request object are considered global and therefore
+     * valid even when the level decreased (though they can be overridden). This
+     * is so for better simulating the effect of directly working against the
+     * request object, and for better integration with JSP or any other template
+     * engines or view-layer technologies that expect the HttpServletRequest to
+     * be the 'only source of truth' for context variables.
+     * ---------------------------------------------------------------------------
+     */
+
+    private static final String PARAM_VARIABLE_NAME = "param";
+    private static final String SESSION_VARIABLE_NAME = "session";
+    private static final String APPLICATION_VARIABLE_NAME = "application";
+
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+    private final HttpSession session;
+    private final ServletContext servletContext;
+
+    private final RequestAttributesVariablesMap requestAttributesVariablesMap;
+    private final Map<String,Object> requestParametersVariablesMap;
+    private final Map<String,Object> sessionAttributesVariablesMap;
+    private final Map<String,Object> applicationAttributesVariablesMap;
+
+
+
+
+    /**
+     * <p>
+     *   Creates a new instance of this {@link IEngineContext} implementation binding engine execution to
+     *   the Servlet API.
+     * </p>
+     * <p>
+     *   Note that implementations of {@link IEngineContext} are not meant to be used in order to call
+     *   the template engine (use implementations of {@link IContext} such as {@link Context} or {@link WebContext}
+     *   instead). This is therefore mostly an <b>internal</b> implementation, and users should have no reason
+     *   to ever call this constructor except in very specific integration/extension scenarios.
+     * </p>
+     *
+     * @param configuration the configuration instance being used.
+     * @param templateData the template data for the template to be processed.
+     * @param templateResolutionAttributes the template resolution attributes.
+     * @param request the servlet request object.
+     * @param response the servlet response object.
+     * @param servletContext the servlet context object.
+     * @param locale the locale.
+     * @param variables the context variables, probably coming from another {@link IContext} implementation.
+     */
+    public JakartaWebEngineContext(
+            final IEngineConfiguration configuration,
+            final TemplateData templateData,
+            final Map<String,Object> templateResolutionAttributes,
+            final HttpServletRequest request, final HttpServletResponse response,
+            final ServletContext servletContext,
+            final Locale locale,
+            final Map<String, Object> variables) {
+
+        super(configuration, templateResolutionAttributes, locale);
+
+        Validate.notNull(request, "Request cannot be null in web variables map");
+        Validate.notNull(response, "Response cannot be null in web variables map");
+        Validate.notNull(servletContext, "Servlet Context cannot be null in web variables map");
+
+        this.request = request;
+        this.response = response;
+        this.session = request.getSession(false);
+        this.servletContext = servletContext;
+
+        this.requestAttributesVariablesMap =
+                new RequestAttributesVariablesMap(configuration, templateData, templateResolutionAttributes, this.request, locale, variables);
+        this.requestParametersVariablesMap = new RequestParametersMap(this.request);
+        this.applicationAttributesVariablesMap = new ServletContextAttributesMap(this.servletContext);
+        this.sessionAttributesVariablesMap = new SessionAttributesMap(this.session);
+
+    }
+
+
+    public HttpServletRequest getRequest() {
+        return this.request;
+    }
+
+
+    public HttpServletResponse getResponse() {
+        return this.response;
+    }
+
+
+    public HttpSession getSession() {
+        return this.session;
+    }
+
+
+    public ServletContext getServletContext() {
+        return this.servletContext;
+    }
+
+
+    public boolean containsVariable(final String name) {
+        if (SESSION_VARIABLE_NAME.equals(name)) {
+            return this.sessionAttributesVariablesMap != null;
+        }
+        if (PARAM_VARIABLE_NAME.equals(name)) {
+            return true;
+        }
+        return APPLICATION_VARIABLE_NAME.equals(name) || this.requestAttributesVariablesMap.containsVariable(name);
+    }
+
+
+    public Object getVariable(final String key) {
+        if (SESSION_VARIABLE_NAME.equals(key)) {
+            return this.sessionAttributesVariablesMap;
+        }
+        if (PARAM_VARIABLE_NAME.equals(key)) {
+            return this.requestParametersVariablesMap;
+        }
+        if (APPLICATION_VARIABLE_NAME.equals(key)) {
+            return this.applicationAttributesVariablesMap;
+        }
+        return this.requestAttributesVariablesMap.getVariable(key);
+    }
+
+
+    public Set<String> getVariableNames() {
+        // Note this set will NOT include 'param', 'session' or 'application', as they are considered special
+        // ways to access attributes/parameters in these Servlet API structures
+        return this.requestAttributesVariablesMap.getVariableNames();
+    }
+
+
+    public void setVariable(final String name, final Object value) {
+        if (SESSION_VARIABLE_NAME.equals(name) ||
+                PARAM_VARIABLE_NAME.equals(name) ||
+                APPLICATION_VARIABLE_NAME.equals(name)) {
+            throw new IllegalArgumentException(
+                    "Cannot set variable called '" + name + "' into web variables map: such name is a reserved word");
+        }
+        this.requestAttributesVariablesMap.setVariable(name, value);
+    }
+
+
+    public void setVariables(final Map<String, Object> variables) {
+        if (variables == null || variables.isEmpty()) {
+            return;
+        }
+        // First perform reserved word check on every variable name to be inserted
+        for (final String name : variables.keySet()) {
+            if (SESSION_VARIABLE_NAME.equals(name) ||
+                    PARAM_VARIABLE_NAME.equals(name) ||
+                    APPLICATION_VARIABLE_NAME.equals(name)) {
+                throw new IllegalArgumentException(
+                        "Cannot set variable called '" + name + "' into web variables map: such name is a reserved word");
+            }
+        }
+        this.requestAttributesVariablesMap.setVariables(variables);
+    }
+
+
+    public void removeVariable(final String name) {
+        if (SESSION_VARIABLE_NAME.equals(name) ||
+                PARAM_VARIABLE_NAME.equals(name) ||
+                APPLICATION_VARIABLE_NAME.equals(name)) {
+            throw new IllegalArgumentException(
+                    "Cannot remove variable called '" + name + "' in web variables map: such name is a reserved word");
+        }
+        this.requestAttributesVariablesMap.removeVariable(name);
+    }
+
+
+    public boolean isVariableLocal(final String name) {
+        return this.requestAttributesVariablesMap.isVariableLocal(name);
+    }
+
+
+    public boolean hasSelectionTarget() {
+        return this.requestAttributesVariablesMap.hasSelectionTarget();
+    }
+
+
+    public Object getSelectionTarget() {
+        return this.requestAttributesVariablesMap.getSelectionTarget();
+    }
+
+
+    public void setSelectionTarget(final Object selectionTarget) {
+        this.requestAttributesVariablesMap.setSelectionTarget(selectionTarget);
+    }
+
+
+
+
+    public IInliner getInliner() {
+        return this.requestAttributesVariablesMap.getInliner();
+    }
+
+    public void setInliner(final IInliner inliner) {
+        this.requestAttributesVariablesMap.setInliner(inliner);
+    }
+
+
+
+
+    public TemplateData getTemplateData() {
+        return this.requestAttributesVariablesMap.getTemplateData();
+    }
+
+    public void setTemplateData(final TemplateData templateData) {
+        this.requestAttributesVariablesMap.setTemplateData(templateData);
+    }
+
+
+    public List<TemplateData> getTemplateStack() {
+        return this.requestAttributesVariablesMap.getTemplateStack();
+    }
+
+
+
+
+    public void setElementTag(final IProcessableElementTag elementTag) {
+        this.requestAttributesVariablesMap.setElementTag(elementTag);
+    }
+
+
+
+
+    public List<IProcessableElementTag> getElementStack() {
+        return this.requestAttributesVariablesMap.getElementStack();
+    }
+
+
+    public List<IProcessableElementTag> getElementStackAbove(final int contextLevel) {
+        return this.requestAttributesVariablesMap.getElementStackAbove(contextLevel);
+    }
+
+
+
+
+    public int level() {
+        return this.requestAttributesVariablesMap.level();
+    }
+
+
+    public void increaseLevel() {
+        this.requestAttributesVariablesMap.increaseLevel();
+    }
+
+
+    public void decreaseLevel() {
+        this.requestAttributesVariablesMap.decreaseLevel();
+    }
+
+
+
+
+    public String getStringRepresentationByLevel() {
+        // Request parameters, session and servlet context can be safely ignored here
+        return this.requestAttributesVariablesMap.getStringRepresentationByLevel();
+    }
+
+
+
+
+    @Override
+    public String toString() {
+        // Request parameters, session and servlet context can be safely ignored here
+        return this.requestAttributesVariablesMap.toString();
+    }
+
+
+
+    static Object resolveLazy(final Object variable) {
+        /*
+         * Check the possibility that this variable is a lazy one, in which case we should not return it directly
+         * but instead make sure it is initialized and return its value.
+         */
+        if (variable != null && variable instanceof ILazyContextVariable) {
+            return ((ILazyContextVariable)variable).getValue();
+        }
+        return variable;
+    }
+
+
+
+
+    private static final class SessionAttributesMap extends NoOpMapImpl {
+
+        private final HttpSession session;
+
+        SessionAttributesMap(final HttpSession session) {
+            super();
+            this.session = session;
+        }
+
+
+        @Override
+        public int size() {
+            if (this.session == null) {
+                return 0;
+            }
+            int size = 0;
+            final Enumeration<String> attributeNames = this.session.getAttributeNames();
+            while (attributeNames.hasMoreElements()) {
+                attributeNames.nextElement();
+                size++;
+            }
+            return size;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            if (this.session == null) {
+                return true;
+            }
+            final Enumeration<String> attributeNames = this.session.getAttributeNames();
+            return !attributeNames.hasMoreElements();
+        }
+
+        @Override
+        public boolean containsKey(final Object key) {
+            // Even if not completely correct to return 'true' for entries that might not exist, this is needed
+            // in order to avoid Spring's MapAccessor throwing an exception when trying to access an element
+            // that doesn't exist -- in the case of request parameters, session and servletContext attributes most
+            // developers would expect null to be returned in such case, and that's what this 'true' will cause.
+            return true;
+        }
+
+        @Override
+        public boolean containsValue(final Object value) {
+            // It wouldn't be consistent to have an 'ad hoc' implementation of #containsKey() but a 100% correct
+            // implementation of #containsValue(), so we are leaving this as unsupported.
+            throw new UnsupportedOperationException("Map does not support #containsValue()");
+        }
+
+        @Override
+        public Object get(final Object key) {
+            if (this.session == null) {
+                return null;
+            }
+            return resolveLazy(this.session.getAttribute(key != null? key.toString() : null));
+        }
+
+        @Override
+        public Set<String> keySet() {
+            if (this.session == null) {
+                return Collections.emptySet();
+            }
+            final Set<String> keySet = new LinkedHashSet<String>(5);
+            final Enumeration<String> attributeNames = this.session.getAttributeNames();
+            while (attributeNames.hasMoreElements()) {
+                keySet.add(attributeNames.nextElement());
+            }
+            return keySet;
+        }
+
+        @Override
+        public Collection<Object> values() {
+            if (this.session == null) {
+                return Collections.emptySet();
+            }
+            final List<Object> values = new ArrayList<Object>(5);
+            final Enumeration<String> attributeNames = this.session.getAttributeNames();
+            while (attributeNames.hasMoreElements()) {
+                values.add(this.session.getAttribute(attributeNames.nextElement()));
+            }
+            return values;
+        }
+
+        @Override
+        public Set<Entry<String,Object>> entrySet() {
+            if (this.session == null) {
+                return Collections.emptySet();
+            }
+            final Set<Entry<String,Object>> entrySet = new LinkedHashSet<Entry<String, Object>>(5);
+            final Enumeration<String> attributeNames = this.session.getAttributeNames();
+            while (attributeNames.hasMoreElements()) {
+                final String key = attributeNames.nextElement();
+                final Object value = this.session.getAttribute(key);
+                entrySet.add(new MapEntry(key, value));
+            }
+            return entrySet;
+        }
+
+    }
+
+
+
+
+    private static final class ServletContextAttributesMap extends NoOpMapImpl {
+
+        private final ServletContext servletContext;
+
+        ServletContextAttributesMap(final ServletContext servletContext) {
+            super();
+            this.servletContext = servletContext;
+        }
+
+
+        @Override
+        public int size() {
+            int size = 0;
+            final Enumeration<String> attributeNames = this.servletContext.getAttributeNames();
+            while (attributeNames.hasMoreElements()) {
+                attributeNames.nextElement();
+                size++;
+            }
+            return size;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            final Enumeration<String> attributeNames = this.servletContext.getAttributeNames();
+            return !attributeNames.hasMoreElements();
+        }
+
+        @Override
+        public boolean containsKey(final Object key) {
+            // Even if not completely correct to return 'true' for entries that might not exist, this is needed
+            // in order to avoid Spring's MapAccessor throwing an exception when trying to access an element
+            // that doesn't exist -- in the case of request parameters, session and servletContext attributes most
+            // developers would expect null to be returned in such case, and that's what this 'true' will cause.
+            return true;
+        }
+
+        @Override
+        public boolean containsValue(final Object value) {
+            // It wouldn't be consistent to have an 'ad hoc' implementation of #containsKey() but a 100% correct
+            // implementation of #containsValue(), so we are leaving this as unsupported.
+            throw new UnsupportedOperationException("Map does not support #containsValue()");
+        }
+
+        @Override
+        public Object get(final Object key) {
+            return resolveLazy(this.servletContext.getAttribute(key != null? key.toString() : null));
+        }
+
+        @Override
+        public Set<String> keySet() {
+            final Set<String> keySet = new LinkedHashSet<String>(5);
+            final Enumeration<String> attributeNames = this.servletContext.getAttributeNames();
+            while (attributeNames.hasMoreElements()) {
+                keySet.add(attributeNames.nextElement());
+            }
+            return keySet;
+        }
+
+        @Override
+        public Collection<Object> values() {
+            final List<Object> values = new ArrayList<Object>(5);
+            final Enumeration<String> attributeNames = this.servletContext.getAttributeNames();
+            while (attributeNames.hasMoreElements()) {
+                values.add(this.servletContext.getAttribute(attributeNames.nextElement()));
+            }
+            return values;
+        }
+
+        @Override
+        public Set<Entry<String,Object>> entrySet() {
+            final Set<Entry<String,Object>> entrySet = new LinkedHashSet<Entry<String, Object>>(5);
+            final Enumeration<String> attributeNames = this.servletContext.getAttributeNames();
+            while (attributeNames.hasMoreElements()) {
+                final String key = attributeNames.nextElement();
+                final Object value = this.servletContext.getAttribute(key);
+                entrySet.add(new MapEntry(key, value));
+            }
+            return entrySet;
+        }
+
+    }
+
+
+
+
+    private static final class RequestParametersMap extends NoOpMapImpl {
+
+        private final HttpServletRequest request;
+
+        RequestParametersMap(final HttpServletRequest request) {
+            super();
+            this.request = request;
+        }
+
+
+        @Override
+        public int size() {
+            return this.request.getParameterMap().size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return this.request.getParameterMap().isEmpty();
+        }
+
+        @Override
+        public boolean containsKey(final Object key) {
+            // Even if not completely correct to return 'true' for entries that might not exist, this is needed
+            // in order to avoid Spring's MapAccessor throwing an exception when trying to access an element
+            // that doesn't exist -- in the case of request parameters, session and servletContext attributes most
+            // developers would expect null to be returned in such case, and that's what this 'true' will cause.
+            return true;
+        }
+
+        @Override
+        public boolean containsValue(final Object value) {
+            // It wouldn't be consistent to have an 'ad hoc' implementation of #containsKey() but a 100% correct
+            // implementation of #containsValue(), so we are leaving this as unsupported.
+            throw new UnsupportedOperationException("Map does not support #containsValue()");
+        }
+
+        @Override
+        public Object get(final Object key) {
+            final String[] parameterValues = this.request.getParameterValues(key != null? key.toString() : null);
+            if (parameterValues == null) {
+                return null;
+            }
+            return new RequestParameterValues(parameterValues);
+        }
+
+        @Override
+        public Set<String> keySet() {
+            return this.request.getParameterMap().keySet();
+        }
+
+        @Override
+        public Collection<Object> values() {
+            Collection<String[]> values = this.request.getParameterMap().values();
+            return new ArrayList<Object>(values);
+        }
+
+        @Override
+        public Set<Entry<String,Object>> entrySet() {
+            Set<Entry<String, String[]>> entries = this.request.getParameterMap().entrySet();
+            Set<Entry<String, Object>> result = new HashSet<Entry<String, Object>>(entries.size());
+            for (Entry<String, String[]> entry : entries) {
+                result.add(new MapEntry(entry.getKey(), entry.getValue()));
+            }
+            return result;
+        }
+
+    }
+
+
+
+
+    private static final class RequestAttributesVariablesMap extends AbstractEngineContext implements IEngineContext {
+
+        private static final int DEFAULT_ELEMENT_HIERARCHY_SIZE = 20;
+        private static final int DEFAULT_LEVELS_SIZE = 10;
+        private static final int DEFAULT_LEVELARRAYS_SIZE = 5;
+
+        private final HttpServletRequest request;
+
+        private int level = 0;
+        private int index = 0;
+        private int[] levels;
+
+        private String[][] names;
+        private Object[][] oldValues;
+        private Object[][] newValues;
+        private int[] levelSizes;
+        private SelectionTarget[] selectionTargets;
+        private IInliner[] inliners;
+        private TemplateData[] templateDatas;
+        private IProcessableElementTag[] elementTags;
+
+        private SelectionTarget lastSelectionTarget = null;
+        private IInliner lastInliner = null;
+        private TemplateData lastTemplateData = null;
+
+        private final List<TemplateData> templateStack;
+
+
+
+        RequestAttributesVariablesMap(
+                final IEngineConfiguration configuration,
+                final TemplateData templateData,
+                final Map<String,Object> templateResolutionAttributes,
+                final HttpServletRequest request,
+                final Locale locale,
+                final Map<String, Object> variables) {
+
+            super(configuration, templateResolutionAttributes, locale);
+
+            this.request = request;
+
+            this.levels = new int[DEFAULT_LEVELS_SIZE];
+            this.names = new String[DEFAULT_LEVELS_SIZE][];
+            this.oldValues = new Object[DEFAULT_LEVELS_SIZE][];
+            this.newValues = new Object[DEFAULT_LEVELS_SIZE][];
+            this.levelSizes = new int[DEFAULT_LEVELS_SIZE];
+            this.selectionTargets = new SelectionTarget[DEFAULT_LEVELS_SIZE];
+            this.inliners = new IInliner[DEFAULT_LEVELS_SIZE];
+            this.templateDatas = new TemplateData[DEFAULT_LEVELS_SIZE];
+
+            this.elementTags = new IProcessableElementTag[DEFAULT_ELEMENT_HIERARCHY_SIZE];
+
+            Arrays.fill(this.levels, Integer.MAX_VALUE);
+            Arrays.fill(this.names, null);
+            Arrays.fill(this.oldValues, null);
+            Arrays.fill(this.newValues, null);
+            Arrays.fill(this.levelSizes, 0);
+            Arrays.fill(this.selectionTargets, null);
+            Arrays.fill(this.inliners, null);
+            Arrays.fill(this.templateDatas, null);
+
+            Arrays.fill(this.elementTags, null);
+
+            this.levels[0] = 0;
+            this.templateDatas[0] = templateData;
+            this.lastTemplateData = templateData;
+
+            this.templateStack = new ArrayList<TemplateData>(DEFAULT_LEVELS_SIZE);
+            this.templateStack.add(templateData);
+
+            if (variables != null) {
+                setVariables(variables);
+            }
+
+        }
+
+
+        public boolean containsVariable(final String name) {
+            return this.request.getAttribute(name) != null;
+        }
+
+
+        public Object getVariable(final String key) {
+            return resolveLazy(this.request.getAttribute(key));
+        }
+
+
+        public Set<String> getVariableNames() {
+            // --------------------------
+            // Note this method relies on HttpServletRequest#getAttributeNames(), which is an extremely slow and
+            // inefficient method in implementations like Apache Tomcat's. So the uses of this method should be
+            // very controlled and reduced to the minimum. Specifically, any call that executes e.g. for every
+            // expression evaluation should be disallowed. Only sporadic uses should be done.
+            // Note also it would not be a good idea to cache the attribute names coming from the request if we
+            // want to keep complete independence of the HttpServletRequest object, so that it can be modified
+            // from the outside (e.g. from other libraries like Tiles) with Thymeleaf perfectly integrating with
+            // those modifications.
+            // --------------------------
+            final Set<String> variableNames = new HashSet<String>(10);
+            final Enumeration<String> attributeNamesEnum = this.request.getAttributeNames();
+            while (attributeNamesEnum.hasMoreElements()) {
+                variableNames.add(attributeNamesEnum.nextElement());
+            }
+            return variableNames;
+
+        }
+
+
+        private int searchNameInIndex(final String name, final int idx) {
+            int n = this.levelSizes[idx];
+            if (name == null) {
+                while (n-- != 0) {
+                    if (this.names[idx][n] == null) {
+                        return n;
+                    }
+                }
+                return -1;
+            }
+            while (n-- != 0) {
+                if (name.equals(this.names[idx][n])) {
+                    return n;
+                }
+            }
+            return -1;
+        }
+
+
+
+
+        public void setVariable(final String name, final Object value) {
+
+            ensureLevelInitialized(true);
+
+            if (this.level > 0) {
+                // We will only take care of new/old values if we are not on level 0
+
+                int levelIndex = searchNameInIndex(name,this.index);
+                if (levelIndex >= 0) {
+
+                    // There already is a registered movement for this key - we should modify it instead of creating a new one
+                    this.newValues[this.index][levelIndex] = value;
+
+                } else {
+
+                    if (this.names[this.index].length == this.levelSizes[this.index]) {
+                        // We need to grow the arrays for this level
+                        this.names[this.index] = Arrays.copyOf(this.names[this.index], this.names[this.index].length + DEFAULT_LEVELARRAYS_SIZE);
+                        this.newValues[this.index] = Arrays.copyOf(this.newValues[this.index], this.newValues[this.index].length + DEFAULT_LEVELARRAYS_SIZE);
+                        this.oldValues[this.index] = Arrays.copyOf(this.oldValues[this.index], this.oldValues[this.index].length + DEFAULT_LEVELARRAYS_SIZE);
+                    }
+
+                    levelIndex = this.levelSizes[this.index]; // We will add at the end
+
+                    this.names[this.index][levelIndex] = name;
+
+                    /*
+                     * Per construction, according to the Servlet API, an attribute set to null and a non-existing
+                     * attribute are exactly the same. So we don't really have a reason to worry about the attribute
+                     * already existing or not when it was set to null.
+                     */
+                    this.oldValues[this.index][levelIndex] = this.request.getAttribute(name);
+
+                    this.newValues[this.index][levelIndex] = value;
+
+                    this.levelSizes[this.index]++;
+
+                }
+
+            }
+
+            // No matter if value is null or not. Value null will be equivalent to .removeAttribute()
+            this.request.setAttribute(name, value);
+
+        }
+
+
+        public void setVariables(final Map<String, Object> variables) {
+            if (variables == null || variables.isEmpty()) {
+                return;
+            }
+            for (final Map.Entry<String,Object> entry : variables.entrySet()) {
+                setVariable(entry.getKey(), entry.getValue());
+            }
+        }
+
+
+        public void removeVariable(final String name) {
+            setVariable(name, null);
+        }
+
+
+
+
+        public boolean isVariableLocal(final String name) {
+
+            if (this.level == 0) {
+                // We are at level 0, so we cannot have local variables at all
+                return false;
+            }
+
+            int n = this.index + 1;
+            while (n-- > 1) { // variables at n == 0 are not local!
+                final int idx = searchNameInIndex(name, n);
+                if (idx >= 0) {
+                    return this.newValues[n][idx] != null;
+                }
+            }
+
+            return false;
+
+        }
+
+
+
+
+        public boolean hasSelectionTarget() {
+            if (this.lastSelectionTarget != null) {
+                return true;
+            }
+            int n = this.index + 1;
+            while (n-- != 0) {
+                if (this.selectionTargets[n] != null) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+
+        public Object getSelectionTarget() {
+            if (this.lastSelectionTarget != null) {
+                return this.lastSelectionTarget.selectionTarget;
+            }
+            int n = this.index + 1;
+            while (n-- != 0) {
+                if (this.selectionTargets[n] != null) {
+                    this.lastSelectionTarget = this.selectionTargets[n];
+                    return this.lastSelectionTarget.selectionTarget;
+                }
+            }
+            return null;
+        }
+
+
+        public void setSelectionTarget(final Object selectionTarget) {
+            ensureLevelInitialized(false);
+            this.lastSelectionTarget = new SelectionTarget(selectionTarget);
+            this.selectionTargets[this.index] = this.lastSelectionTarget;
+        }
+
+
+
+
+        public IInliner getInliner() {
+            if (this.lastInliner != null) {
+                if (this.lastInliner == NoOpInliner.INSTANCE) {
+                    return null;
+                }
+                return this.lastInliner;
+            }
+            int n = this.index + 1;
+            while (n-- != 0) {
+                if (this.inliners[n] != null) {
+                    this.lastInliner = this.inliners[n];
+                    if (this.lastInliner == NoOpInliner.INSTANCE) {
+                        return null;
+                    }
+                    return this.lastInliner;
+                }
+            }
+            return null;
+        }
+
+
+        public void setInliner(final IInliner inliner) {
+            ensureLevelInitialized(false);
+            // We use NoOpInliner.INSTACE in order to signal when inlining has actually been disabled
+            this.lastInliner = (inliner == null? NoOpInliner.INSTANCE : inliner);
+            this.inliners[this.index] = this.lastInliner;
+        }
+
+
+
+
+        public TemplateData getTemplateData() {
+            if (this.lastTemplateData != null) {
+                return this.lastTemplateData;
+            }
+            int n = this.index + 1;
+            while (n-- != 0) {
+                if (this.templateDatas[n] != null) {
+                    this.lastTemplateData = this.templateDatas[n];
+                    return this.lastTemplateData;
+                }
+            }
+            return null;
+        }
+
+
+        public void setTemplateData(final TemplateData templateData) {
+            Validate.notNull(templateData, "Template Data cannot be null");
+            ensureLevelInitialized(false);
+            this.lastTemplateData = templateData;
+            this.templateDatas[this.index] = this.lastTemplateData;
+            this.templateStack.clear();
+        }
+
+
+
+
+        public List<TemplateData> getTemplateStack() {
+            if (!this.templateStack.isEmpty()) {
+                // If would have been empty if we had just decreased a level or added a new template
+                return Collections.unmodifiableList(new ArrayList<TemplateData>(this.templateStack));
+            }
+            for (int i = 0; i <= this.index; i++) {
+                if (this.templateDatas[i] != null) {
+                    this.templateStack.add(this.templateDatas[i]);
+                }
+            }
+
+            return Collections.unmodifiableList(new ArrayList<TemplateData>(this.templateStack));
+        }
+
+
+
+
+        public void setElementTag(final IProcessableElementTag elementTag) {
+            if (this.elementTags.length <= this.level) {
+                this.elementTags = Arrays.copyOf(this.elementTags, Math.max(this.level, this.elementTags.length + DEFAULT_ELEMENT_HIERARCHY_SIZE));
+            }
+            this.elementTags[this.level] = elementTag;
+        }
+
+
+
+
+        public List<IProcessableElementTag> getElementStack() {
+            final List<IProcessableElementTag> elementStack = new ArrayList<IProcessableElementTag>(this.level);
+            for (int i = 0; i <= this.level && i < this.elementTags.length; i++) {
+                if (this.elementTags[i] != null) {
+                    elementStack.add(this.elementTags[i]);
+                }
+            }
+
+            return Collections.unmodifiableList(elementStack);
+        }
+
+
+        public List<IProcessableElementTag> getElementStackAbove(final int contextLevel) {
+            final List<IProcessableElementTag> elementStack = new ArrayList<IProcessableElementTag>(this.level);
+            for (int i = contextLevel + 1; i <= this.level && i < this.elementTags.length; i++) {
+                if (this.elementTags[i] != null) {
+                    elementStack.add(this.elementTags[i]);
+                }
+            }
+
+            return Collections.unmodifiableList(elementStack);
+        }
+
+
+
+
+        private void ensureLevelInitialized(final boolean initVariables) {
+
+            // First, check if the current index already signals the current level (in which case, everything is OK)
+            if (this.levels[this.index] != this.level) {
+
+                // The current level still had no index assigned -- we must do it, and maybe even grow structures
+
+                this.index++; // This new index will be the one for our level
+
+                if (this.levels.length == this.index) {
+                    this.levels = Arrays.copyOf(this.levels, this.levels.length + DEFAULT_LEVELS_SIZE);
+                    Arrays.fill(this.levels, this.index, this.levels.length, Integer.MAX_VALUE); // We fill the new places with MAX_VALUE
+                    this.names = Arrays.copyOf(this.names, this.names.length + DEFAULT_LEVELS_SIZE);
+                    this.newValues = Arrays.copyOf(this.newValues, this.newValues.length + DEFAULT_LEVELS_SIZE);
+                    this.oldValues = Arrays.copyOf(this.oldValues, this.oldValues.length + DEFAULT_LEVELS_SIZE);
+                    this.levelSizes = Arrays.copyOf(this.levelSizes, this.levelSizes.length + DEFAULT_LEVELS_SIZE);
+                    // No need to initialize new places in this.levelSizes as copyOf already fills with zeroes
+                    this.selectionTargets = Arrays.copyOf(this.selectionTargets, this.selectionTargets.length + DEFAULT_LEVELS_SIZE);
+                    this.inliners = Arrays.copyOf(this.inliners, this.inliners.length + DEFAULT_LEVELS_SIZE);
+                    this.templateDatas = Arrays.copyOf(this.templateDatas, this.templateDatas.length + DEFAULT_LEVELS_SIZE);
+                }
+
+                this.levels[this.index] = this.level;
+
+            }
+
+            if (this.level > 0) {
+                // We will only take care of new/old values if we are not on level 0
+
+                if (initVariables && this.names[this.index] == null) {
+                    // the arrays for this level have still not been created
+
+                    this.names[this.index] = new String[DEFAULT_LEVELARRAYS_SIZE];
+                    Arrays.fill(this.names[this.index], null);
+
+                    this.newValues[this.index] = new Object[DEFAULT_LEVELARRAYS_SIZE];
+                    Arrays.fill(this.newValues[this.index], null);
+
+                    this.oldValues[this.index] = new Object[DEFAULT_LEVELARRAYS_SIZE];
+                    Arrays.fill(this.oldValues[this.index], null);
+
+                    this.levelSizes[this.index] = 0;
+
+                }
+
+            }
+
+        }
+
+
+
+
+        public int level() {
+            return this.level;
+        }
+
+
+        public void increaseLevel() {
+            this.level++;
+        }
+
+
+        public void decreaseLevel() {
+
+            Validate.isTrue(this.level > 0, "Cannot decrease variable map level below 0");
+
+            if (this.levels[this.index] == this.level) {
+
+                this.levels[this.index] = Integer.MAX_VALUE;
+
+                if (this.names[this.index] != null && this.levelSizes[this.index] > 0) {
+                    // There were movements at this level, so we have to revert them
+
+                    int n = this.levelSizes[this.index];
+                    while (n-- != 0) {
+                        final String name = this.names[this.index][n];
+                        final Object newValue = this.newValues[this.index][n];
+                        final Object oldValue = this.oldValues[this.index][n];
+                        final Object currentValue = this.request.getAttribute(name);
+                        if (newValue == currentValue) {
+                            // Only if the value matches, in order to avoid modifying values that have been set directly
+                            // into the request.
+                            this.request.setAttribute(name,oldValue);
+                        }
+                    }
+                    this.levelSizes[this.index] = 0;
+
+                }
+
+                this.selectionTargets[this.index] = null;
+                this.inliners[this.index] = null;
+                this.templateDatas[this.index] = null;
+                this.index--;
+
+                // These might not belong to this level, but just in case...
+                this.lastSelectionTarget = null;
+                this.lastInliner = null;
+                this.lastTemplateData = null;
+                this.templateStack.clear();
+
+            }
+
+            if (this.level < this.elementTags.length) {
+                this.elementTags[this.level] = null;
+            }
+
+            this.level--;
+
+        }
+
+
+
+
+        public String getStringRepresentationByLevel() {
+
+            final StringBuilder strBuilder = new StringBuilder();
+            strBuilder.append('{');
+            final Map<String,Object> oldValuesSum = new LinkedHashMap<String, Object>();
+            int n = this.index + 1;
+            while (n-- != 1) {
+                final Map<String,Object> levelVars = new LinkedHashMap<String, Object>();
+                if (this.names[n] != null && this.levelSizes[n] > 0) {
+                    for (int i = 0; i < this.levelSizes[n]; i++) {
+                        final String name = this.names[n][i];
+                        final Object newValue = this.newValues[n][i];
+                        final Object oldValue = this.oldValues[n][i];
+                        if (newValue == oldValue) {
+                            // This is a no-op!
+                            continue;
+                        }
+                        if (!oldValuesSum.containsKey(name)) {
+                            // This means that, either the value in the request is the same as the newValue, or it was modified
+                            // directly at the request and we need to discard this entry.
+                            if (newValue != this.request.getAttribute(name)) {
+                                continue;
+                            }
+                        } else {
+                            // This means that, either the old value in the map is the same as the newValue, or it was modified
+                            // directly at the request and we need to discard this entry.
+                            if (newValue != oldValuesSum.get(name)) {
+                                continue;
+                            }
+                        }
+                        levelVars.put(name, newValue);
+                        oldValuesSum.put(name, oldValue);
+                    }
+                }
+                if (!levelVars.isEmpty() || this.selectionTargets[n] != null || this.inliners[n] != null) {
+                    if (strBuilder.length() > 1) {
+                        strBuilder.append(',');
+                    }
+                    strBuilder.append(this.levels[n]).append(":");
+                    if (!levelVars.isEmpty() || n == 0) {
+                        strBuilder.append(levelVars);
+                    }
+                    if (this.selectionTargets[n] != null) {
+                        strBuilder.append("<").append(this.selectionTargets[n].selectionTarget).append(">");
+                    }
+                    if (this.inliners[n] != null) {
+                        strBuilder.append("[").append(this.inliners[n].getName()).append("]");
+                    }
+                    if (this.templateDatas[n] != null) {
+                        strBuilder.append("(").append(this.templateDatas[n].getTemplate()).append(")");
+                    }
+                }
+            }
+            final Map<String,Object> requestAttributes = new LinkedHashMap<String, Object>();
+            final Enumeration<String> attrNames = this.request.getAttributeNames();
+            while (attrNames.hasMoreElements()) {
+                final String name = attrNames.nextElement();
+                if (oldValuesSum.containsKey(name)) {
+                    final Object oldValue = oldValuesSum.get(name);
+                    if (oldValue != null) {
+                        requestAttributes.put(name, oldValuesSum.get(name));
+                    }
+                    oldValuesSum.remove(name);
+                } else {
+                    requestAttributes.put(name, this.request.getAttribute(name));
+                }
+            }
+            for (Map.Entry<String,Object> oldValuesSumEntry : oldValuesSum.entrySet()) {
+                final String name = oldValuesSumEntry.getKey();
+                if (!requestAttributes.containsKey(name)) {
+                    final Object oldValue = oldValuesSumEntry.getValue();
+                    if (oldValue != null) {
+                        requestAttributes.put(name, oldValue);
+                    }
+                }
+            }
+            if (strBuilder.length() > 1) {
+                strBuilder.append(',');
+            }
+            strBuilder.append(this.levels[n]).append(":");
+            strBuilder.append(requestAttributes.toString());
+            if (this.selectionTargets[0] != null) {
+                strBuilder.append("<").append(this.selectionTargets[0].selectionTarget).append(">");
+            }
+            if (this.inliners[0] != null) {
+                strBuilder.append("[").append(this.inliners[0].getName()).append("]");
+            }
+            if (this.templateDatas[0] != null) {
+                strBuilder.append("(").append(this.templateDatas[0].getTemplate()).append(")");
+            }
+            strBuilder.append("}[");
+            strBuilder.append(this.level);
+            strBuilder.append(']');
+            return strBuilder.toString();
+
+        }
+
+
+
+
+        @Override
+        public String toString() {
+
+            final Map<String,Object> equivalentMap = new LinkedHashMap<String, Object>();
+            final Enumeration<String> attributeNamesEnum = this.request.getAttributeNames();
+            while (attributeNamesEnum.hasMoreElements()) {
+                final String name = attributeNamesEnum.nextElement();
+                equivalentMap.put(name, this.request.getAttribute(name));
+            }
+            final String textInliningStr = (getInliner() != null? "[" + getInliner().getName() + "]" : "" );
+            final String templateDataStr = "(" + getTemplateData().getTemplate() + ")";
+            return equivalentMap.toString() + (hasSelectionTarget()? "<" + getSelectionTarget() + ">" : "") + textInliningStr + templateDataStr;
+
+        }
+
+
+
+
+        /*
+         * This class works as a wrapper for the selection target, in order to differentiate whether we
+         * have set a selection target, we have not, or we have set it but it's null
+         */
+        private static final class SelectionTarget {
+
+            final Object selectionTarget;
+
+            SelectionTarget(final Object selectionTarget) {
+                super();
+                this.selectionTarget = selectionTarget;
+            }
+
+        }
+
+
+    }
+
+
+
+
+
+    private abstract static class NoOpMapImpl implements Map<String,Object> {
+
+        protected NoOpMapImpl() {
+            super();
+        }
+
+        public int size() {
+            return 0;
+        }
+
+        public boolean isEmpty() {
+            return true;
+        }
+
+        public boolean containsKey(final Object key) {
+            return false;
+        }
+
+        public boolean containsValue(final Object value) {
+            return false;
+        }
+
+        public Object get(final Object key) {
+            return null;
+        }
+
+        public Object put(final String key, final Object value) {
+            throw new UnsupportedOperationException("Cannot add new entry: map is immutable");
+        }
+
+        public Object remove(final Object key) {
+            throw new UnsupportedOperationException("Cannot remove entry: map is immutable");
+        }
+
+        public void putAll(final Map<? extends String, ? extends Object> m) {
+            throw new UnsupportedOperationException("Cannot add new entry: map is immutable");
+        }
+
+        public void clear() {
+            throw new UnsupportedOperationException("Cannot clear: map is immutable");
+        }
+
+        public Set<String> keySet() {
+            return Collections.emptySet();
+        }
+
+        public Collection<Object> values() {
+            return Collections.emptyList();
+        }
+
+        public Set<Entry<String,Object>> entrySet() {
+            return Collections.emptySet();
+        }
+
+
+        static final class MapEntry implements Entry<String,Object> {
+
+            private final String key;
+            private final Object value;
+
+            MapEntry(final String key, final Object value) {
+                super();
+                this.key = key;
+                this.value = value;
+            }
+
+            public String getKey() {
+                return this.key;
+            }
+
+            public Object getValue() {
+                return this.value;
+            }
+
+            public Object setValue(final Object value) {
+                throw new UnsupportedOperationException("Cannot set value: map is immutable");
+            }
+
+        }
+
+
+    }
+
+
+
+    private static final class RequestParameterValues extends AbstractList<String> {
+
+        private final String[] parameterValues;
+        public final int length;
+
+        RequestParameterValues(final String[] parameterValues) {
+            this.parameterValues = parameterValues;
+            this.length = this.parameterValues.length;
+        }
+
+        @Override
+        public int size() {
+            return this.length;
+        }
+
+        @Override
+        public Object[] toArray() {
+            return this.parameterValues.clone();
+        }
+
+        @Override
+        public <T> T[] toArray(final T[] arr) {
+            if (arr.length < this.length) {
+                final T[] copy = (T[]) Array.newInstance(arr.getClass().getComponentType(), this.length);
+                System.arraycopy(this.parameterValues, 0, copy, 0, this.length);
+                return copy;
+            }
+            System.arraycopy(this.parameterValues, 0, arr, 0, this.length);
+            if (arr.length > this.length) {
+                arr[this.length] = null;
+            }
+            return arr;
+        }
+
+        @Override
+        public String get(final int index) {
+            return this.parameterValues[index];
+        }
+
+        @Override
+        public int indexOf(final Object obj) {
+            final String[] a = this.parameterValues;
+            if (obj == null) {
+                for (int i = 0; i < a.length; i++) {
+                    if (a[i] == null) {
+                        return i;
+                    }
+                }
+            } else {
+                for (int i = 0; i < a.length; i++) {
+                    if (obj.equals(a[i])) {
+                        return i;
+                    }
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public boolean contains(final Object obj) {
+            return indexOf(obj) != -1;
+        }
+
+
+        @Override
+        public String toString() {
+            // This toString() method will be responsible of outputting non-indexed request parameters in the
+            // way most people expect, i.e. return parameterValues[0] when accessed without index and parameter is
+            // single-valued (${param.a}), returning ArrayList#toString() when accessed without index and parameter
+            // is multi-valued, and finally return the specific value when accessed with index (${param.a[0]})
+            if (this.length == 0) {
+                return "";
+            }
+            if (this.length == 1) {
+                return this.parameterValues[0];
+            }
+            return super.toString();
+        }
+    }
+
+}

--- a/src/main/java/org/thymeleaf/context/JakartaWebExpressionContext.java
+++ b/src/main/java/org/thymeleaf/context/JakartaWebExpressionContext.java
@@ -1,0 +1,100 @@
+/*
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2018, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * =============================================================================
+ */
+package org.thymeleaf.context;
+
+import org.thymeleaf.IEngineConfiguration;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * <p>
+ *   Basic web-oriented implementation of the {@link IExpressionContext} and {@link IWebContext} interfaces.
+ * </p>
+ * <p>
+ *   This class is not thread-safe, and should not be shared across executions of templates.
+ * </p>
+ *
+ * @author Daniel Fern&aacute;ndez
+ *
+ * @since 3.0.0
+ *
+ */
+public final class JakartaWebExpressionContext extends AbstractExpressionContext implements IJakartaWebContext {
+
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+    private final ServletContext servletContext;
+
+
+    public JakartaWebExpressionContext(final IEngineConfiguration configuration,
+									   final HttpServletRequest request, final HttpServletResponse response,
+									   final ServletContext servletContext) {
+        super(configuration);
+        this.request = request;
+        this.response = response;
+        this.servletContext = servletContext;
+    }
+
+
+    public JakartaWebExpressionContext(final IEngineConfiguration configuration,
+									   final HttpServletRequest request, final HttpServletResponse response,
+									   final ServletContext servletContext,
+									   final Locale locale) {
+        super(configuration, locale);
+        this.request = request;
+        this.response = response;
+        this.servletContext = servletContext;
+    }
+
+
+    public JakartaWebExpressionContext(
+            final IEngineConfiguration configuration,
+            final HttpServletRequest request, final HttpServletResponse response,
+            final ServletContext servletContext,
+            final Locale locale, final Map<String, Object> variables) {
+        super(configuration, locale, variables);
+        this.request = request;
+        this.response = response;
+        this.servletContext = servletContext;
+    }
+
+
+    public HttpServletRequest getRequest() {
+        return this.request;
+    }
+
+    public HttpSession getSession() {
+        return this.request.getSession(false);
+    }
+
+    public HttpServletResponse getResponse() {
+        return this.response;
+    }
+
+    public ServletContext getServletContext() {
+        return this.servletContext;
+    }
+
+}

--- a/src/main/java/org/thymeleaf/context/StandardEngineContextFactory.java
+++ b/src/main/java/org/thymeleaf/context/StandardEngineContextFactory.java
@@ -79,6 +79,13 @@ public final class StandardEngineContextFactory implements IEngineContextFactory
                         webContext.getRequest(), webContext.getResponse(), webContext.getServletContext(),
                         webContext.getLocale(), Collections.EMPTY_MAP);
             }
+            if (context instanceof IJakartaWebContext) {
+                final IJakartaWebContext webContext = (IJakartaWebContext)context;
+                return new JakartaWebEngineContext(
+                        configuration, templateData, templateResolutionAttributes,
+                        webContext.getRequest(), webContext.getResponse(), webContext.getServletContext(),
+                        webContext.getLocale(), Collections.EMPTY_MAP);
+            }
             return new EngineContext(
                     configuration, templateData, templateResolutionAttributes,
                     context.getLocale(), Collections.EMPTY_MAP);
@@ -91,6 +98,13 @@ public final class StandardEngineContextFactory implements IEngineContextFactory
         if (context instanceof IWebContext) {
             final IWebContext webContext = (IWebContext)context;
             return new WebEngineContext(
+                    configuration, templateData, templateResolutionAttributes,
+                    webContext.getRequest(), webContext.getResponse(), webContext.getServletContext(),
+                    webContext.getLocale(), variables);
+        }
+        if (context instanceof IJakartaWebContext) {
+            final IJakartaWebContext webContext = (IJakartaWebContext)context;
+            return new JakartaWebEngineContext(
                     configuration, templateData, templateResolutionAttributes,
                     webContext.getRequest(), webContext.getResponse(), webContext.getServletContext(),
                     webContext.getLocale(), variables);

--- a/src/main/java/org/thymeleaf/linkbuilder/JakartaLinkBuilder.java
+++ b/src/main/java/org/thymeleaf/linkbuilder/JakartaLinkBuilder.java
@@ -1,0 +1,555 @@
+/*
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2018, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * =============================================================================
+ */
+package org.thymeleaf.linkbuilder;
+
+import org.thymeleaf.context.IExpressionContext;
+import org.thymeleaf.context.IJakartaWebContext;
+import org.thymeleaf.exceptions.TemplateProcessingException;
+import org.thymeleaf.util.Validate;
+import org.unbescape.uri.UriEscape;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * <p>
+ *   Standard implementation of {@link ILinkBuilder}.
+ * </p>
+ * <p>
+ *   This class will build link URLs using (by default) the Java Servlet API when the specified URLs are
+ *   context-relative, given the need to obtain the context path and add it to the URL. Also, when an
+ *   {@link IJakartaWebContext} implementation is used as context, URLs will be passed to
+ *   the standard {@code HttpSerlvetResponse.encodeURL(...)} method before returning.
+ * </p>
+ * <p>
+ *   Note however that the Servlet-API specific part of this behaviour is configurable and confined to a set of
+ *   {@code protected} methods that can be overwritten by subclasses that want to offer a link building
+ *   behaviour very similar to the standard one, but without any dependencies on the Servlet API (e.g. extracting
+ *   URL context paths from a framework artifact other than {@code HttpServletRequest}).
+ * </p>
+ * <p>
+ *   This implementation will only return {@code null} at {@link #buildLink(IExpressionContext, String, Map)}
+ *   if the specified {@code base} argument is {@code null}.
+ * </p>
+ *
+ * @author Daniel Fern&aacute;ndez
+ *
+ * @since 3.0.0
+ */
+public class JakartaLinkBuilder extends AbstractLinkBuilder {
+
+    protected enum LinkType { ABSOLUTE, CONTEXT_RELATIVE, SERVER_RELATIVE, BASE_RELATIVE }
+
+    private static final char URL_TEMPLATE_DELIMITER_PREFIX = '{';
+    private static final char URL_TEMPLATE_DELIMITER_SUFFIX = '}';
+    private static final String URL_TEMPLATE_DELIMITER_SEGMENT_PREFIX = "{/";
+
+
+
+    public JakartaLinkBuilder() {
+        super();
+    }
+
+
+
+
+    public final String buildLink(
+            final IExpressionContext context, final String base, final Map<String, Object> parameters) {
+
+        Validate.notNull(context, "Expression context cannot be null");
+
+        if (base == null) {
+            return null;
+        }
+
+        // We need to create a copy that is: 1. defensive, 2. mutable
+        final Map<String,Object> linkParameters =
+                (parameters == null || parameters.size() == 0? null : new LinkedHashMap<String, Object>(parameters));
+
+        filterOutJavaScriptLinks(base);
+
+        final LinkType linkType;
+        if (isLinkBaseAbsolute(base)) {
+            linkType = LinkType.ABSOLUTE;
+        } else if (isLinkBaseContextRelative(base)) {
+            linkType = LinkType.CONTEXT_RELATIVE;
+        } else if (isLinkBaseServerRelative(base)) {
+            linkType = LinkType.SERVER_RELATIVE;
+        } else {
+            linkType = LinkType.BASE_RELATIVE;
+        }
+
+
+        /*
+         * Compute URL fragments (selectors after '#') so that they can be output at the end of
+         * the URL, after parameters.
+         */
+        final int hashPosition = findCharInSequence(base, '#');
+
+
+        /*
+         * Compute whether we might have variable templates (e.g. Spring Path Variables) inside this link base
+         * that we might need to resolve afterwards
+         */
+        final boolean mightHaveVariableTemplates = findCharInSequence(base, URL_TEMPLATE_DELIMITER_PREFIX) >= 0;
+
+
+        /*
+         * Precompute the context path, so that it can be afterwards used for determining if it has to be added to the
+         * URL (in case it is context-relative) or not.
+         *
+         * Note we give subclasses the opportunity to customize the computation of this context path.
+         */
+        final String contextPath =
+                (linkType == LinkType.CONTEXT_RELATIVE? computeContextPath(context, base, parameters) : null);
+        final boolean contextPathEmpty = contextPath == null || contextPath.length() == 0 || contextPath.equals("/");
+
+
+        /*
+         * SHORTCUT - just before starting to work with StringBuilders, and in the case that we know: 1. That the URL is
+         *            absolute, relative or context-relative with no context; 2. That there are no parameters; and
+         *            3. That there are no URL fragments -> then just return the base URL String without further
+         *            processing (except HttpServletResponse-encoding if needed, of course...)
+         */
+        if (contextPathEmpty && linkType != LinkType.SERVER_RELATIVE &&
+                (linkParameters == null || linkParameters.size() == 0) && hashPosition < 0 && !mightHaveVariableTemplates) {
+            return processLink(context, base);
+        }
+
+
+        /*
+         * Build the StringBuilder that will be used as a base for all URL-related operations from now on: variable
+         * templates, parameters, URL fragments...
+         */
+        StringBuilder linkBase = new StringBuilder(base);
+
+
+        /*
+         * Compute URL fragments (selectors after '#') so that they can be output at the end of
+         * the URL, after parameters.
+         */
+        String urlFragment = "";
+        // If hash position == 0 we will not consider it as marking an
+        // URL fragment.
+        if (hashPosition > 0) {
+            // URL fragment String will include the # sign
+            urlFragment = linkBase.substring(hashPosition);
+            linkBase.delete(hashPosition, linkBase.length());
+        }
+
+
+        /*
+         * Replace those variable templates that might appear referenced in the path itself, as for example, Spring
+         * "Path Variables" (e.g. '/something/{variable}/othersomething')
+         */
+        if (mightHaveVariableTemplates) {
+            linkBase = replaceTemplateParamsInBase(linkBase, linkParameters);
+        }
+
+
+        /*
+         * Process parameters (those that have not already been processed as a result of replacing template
+         * parameters in base).
+         */
+        if (linkParameters != null && linkParameters.size() > 0) {
+
+            final boolean linkBaseHasQuestionMark = findCharInSequence(linkBase,'?') >= 0;
+
+            // If there is no '?' in linkBase, we have to replace with first '&' with '?'
+            if (linkBaseHasQuestionMark) {
+                linkBase.append('&');
+            } else {
+                linkBase.append('?');
+            }
+
+            // Build the parameters query. The result will always start with '&'
+            processAllRemainingParametersAsQueryParams(linkBase, linkParameters);
+
+        }
+
+
+        /*
+         * Once parameters have been added (if there are parameters), we can add the URL fragment
+         */
+        if (urlFragment.length() > 0) {
+            linkBase.append(urlFragment);
+        }
+
+
+        /*
+         * If link base is server relative, we will delete now the leading '~' character so that it starts with '/'
+         */
+        if (linkType == LinkType.SERVER_RELATIVE) {
+            linkBase.delete(0,1);
+        }
+
+
+        /*
+         * It's finally a good moment to insert the context path if it is not empty
+         */
+        if (linkType == LinkType.CONTEXT_RELATIVE && !contextPathEmpty) {
+            // Add the application's context path at the beginning
+            linkBase.insert(0, contextPath);
+        }
+
+
+        /*
+         * Return the link, first performing the last processing on it. This will normally perform a standard
+         * HttpServletResponse.encodeUrl(...) operation on it, but will give any subclasses the opportunity to
+         * customize this behaviour (in case, for instance, they don't want to rely on the Java Servlet API).
+         */
+        return processLink(context, linkBase.toString());
+
+    }
+
+
+
+
+    private static int findCharInSequence(final CharSequence seq, final char character) {
+        int n = seq.length();
+        while (n-- != 0) {
+            final char c = seq.charAt(n);
+            if (c == character) {
+                return n;
+            }
+        }
+        return -1;
+    }
+
+
+    private static void filterOutJavaScriptLinks(final CharSequence linkBase) {
+        if (linkBase.length() >= 11 &&
+                Character.toLowerCase(linkBase.charAt(0)) == 'j' &&
+                Character.toLowerCase(linkBase.charAt(1)) == 'a' &&
+                Character.toLowerCase(linkBase.charAt(2)) == 'v' &&
+                Character.toLowerCase(linkBase.charAt(3)) == 'a' &&
+                Character.toLowerCase(linkBase.charAt(4)) == 's' &&
+                Character.toLowerCase(linkBase.charAt(5)) == 'c' &&
+                Character.toLowerCase(linkBase.charAt(6)) == 'r' &&
+                Character.toLowerCase(linkBase.charAt(7)) == 'i' &&
+                Character.toLowerCase(linkBase.charAt(8)) == 'p' &&
+                Character.toLowerCase(linkBase.charAt(9)) == 't' &&
+                Character.toLowerCase(linkBase.charAt(10)) == ':') {
+
+            throw new TemplateProcessingException(
+                    "'javascript:' is forbidden in this context. Link expressions cannot " +
+                    "contain inlined JavaScript code.");
+
+        }
+    }
+
+
+
+    private static boolean isLinkBaseAbsolute(final CharSequence linkBase) {
+        final int linkBaseLen = linkBase.length();
+        if (linkBaseLen < 2) {
+            return false;
+        }
+        final char c0 = linkBase.charAt(0);
+        if (c0 == 'm' || c0 == 'M') {
+            // Let's check for "mailto:"
+            if (linkBase.length() >= 7 &&
+                    Character.toLowerCase(linkBase.charAt(1)) == 'a' &&
+                    Character.toLowerCase(linkBase.charAt(2)) == 'i' &&
+                    Character.toLowerCase(linkBase.charAt(3)) == 'l' &&
+                    Character.toLowerCase(linkBase.charAt(4)) == 't' &&
+                    Character.toLowerCase(linkBase.charAt(5)) == 'o' &&
+                    Character.toLowerCase(linkBase.charAt(6)) == ':') {
+                return true;
+            }
+        } else if (c0 == '/') {
+            return linkBase.charAt(1) == '/'; // It starts with '//' -> true, any other '/x' -> false
+        }
+        for (int i = 0; i < (linkBaseLen - 2); i++) {
+            // Let's try to find the '://' sequence anywhere in the base --> true
+            if (linkBase.charAt(i) == ':' && linkBase.charAt(i + 1) == '/' && linkBase.charAt(i + 2) == '/') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    private static boolean isLinkBaseContextRelative(final CharSequence linkBase) {
+        // For this to be true, it should start with '/', but not with '//'
+        if (linkBase.length() == 0 || linkBase.charAt(0) != '/') {
+            return false;
+        }
+        return linkBase.length() == 1 || linkBase.charAt(1) != '/';
+    }
+
+
+    private static boolean isLinkBaseServerRelative(final CharSequence linkBase) {
+        // For this to be true, it should start with '~/'
+        return (linkBase.length() >= 2 && linkBase.charAt(0) == '~' && linkBase.charAt(1) == '/');
+    }
+
+
+
+
+
+
+
+    private static StringBuilder replaceTemplateParamsInBase(final StringBuilder linkBase, final Map<String, Object> parameters) {
+
+        /*
+         * If parameters is null, there's nothing to do
+         */
+        if (parameters == null) {
+            return linkBase;
+        }
+
+        /*
+         * Search {templateVar} in linkBase, and replace with value.
+         * Parameters can be multivalued, in which case they will be comma-separated.
+         * Parameter values will be URL-path-encoded. If there is a '?' char, only parameter values before this
+         * char will be URL-path-encoded, whereas parameters after it will be URL-query-encoded.
+         */
+
+        final int questionMarkPosition = findCharInSequence(linkBase, '?');
+
+        final Set<String> parameterNames = parameters.keySet();
+        Set<String> alreadyProcessedParameters = null;
+
+        for (final String parameterName : parameterNames) {
+
+            // We default to escaping as a path, not a path segment
+            boolean escapeAsPathSegment = false;
+
+            // We use the text repository in order to avoid the unnecessary creation of too many instances of the same string
+            String template = URL_TEMPLATE_DELIMITER_PREFIX + parameterName + URL_TEMPLATE_DELIMITER_SUFFIX;
+
+            int templateIndex = linkBase.indexOf(template); // not great, because StringBuilder.indexOf ends up calling template.toCharArray(), but...
+
+            if (templateIndex < 0) {
+                template = URL_TEMPLATE_DELIMITER_SEGMENT_PREFIX + parameterName + URL_TEMPLATE_DELIMITER_SUFFIX;
+                templateIndex = linkBase.indexOf(template);
+
+                if (templateIndex < 0) {
+                    // This parameter is not one of those used in path variables
+                    continue;
+                }
+
+                // We need to escape this parameter value as a path segment rather than a path
+                escapeAsPathSegment = true;
+            }
+
+            // Add the parameter name to the set of processed ones so that it is later removed from the parameters object
+            if (alreadyProcessedParameters == null) {
+                alreadyProcessedParameters = new HashSet<String>(parameterNames.size());
+            }
+            alreadyProcessedParameters.add(parameterName);
+
+            // Compute the replacement (unescaped!)
+            final Object parameterValue = parameters.get(parameterName);
+            final String templateReplacement = formatParameterValueAsUnescapedVariableTemplate(parameterValue);
+            final int templateReplacementLen = templateReplacement.length();
+
+            // We will now use a the StringBuilder itself for replacing all appearances of the variable template in
+            // the link base. Note we do this instead of using String#replace() because String#replace internally uses
+            // pattern matching and is very slow :-(
+            final int templateLen = template.length();
+            int start = templateIndex;
+            while (start > -1) {
+                // Depending on whether the template appeared before or after the ?, we will apply different escaping
+                final String escapedReplacement =
+                        (questionMarkPosition == -1 || start < questionMarkPosition?
+                                (escapeAsPathSegment ? UriEscape.escapeUriPathSegment(templateReplacement) : UriEscape.escapeUriPath(templateReplacement))
+                                : UriEscape.escapeUriQueryParam(templateReplacement));
+                linkBase.replace(start, start + templateLen, escapedReplacement);
+                start = linkBase.indexOf(template, start + templateReplacementLen);
+            }
+
+        }
+
+        if (alreadyProcessedParameters != null) {
+            for (final String alreadyProcessedParameter : alreadyProcessedParameters) {
+                parameters.remove(alreadyProcessedParameter);
+            }
+        }
+
+        return linkBase;
+
+    }
+
+
+
+
+
+    /*
+     * This method will return a String containing all the values for a specific parameter, separated with commas
+     * and suitable therefore to be used as variable template (path variables) replacements
+     */
+    private static String formatParameterValueAsUnescapedVariableTemplate(final Object parameterValue) {
+        // Get the value
+        if (parameterValue == null) { // If null (= NO_VALUE), empty String
+            return "";
+        }
+        // If it is not multivalued (e.g. non-List) simply escape and return
+        if (!(parameterValue instanceof List<?>)) {
+            return parameterValue.toString();
+        }
+        // It is multivalued, so iterate and escape each item (no need to escape the comma separating them, it's an allowed char)
+        final List<?> values = (List<?>)parameterValue;
+        final int valuesLen = values.size();
+        final StringBuilder strBuilder = new StringBuilder(valuesLen * 16);
+        for (int i = 0; i < valuesLen; i++) {
+            final Object valueItem = values.get(i);
+            if (strBuilder.length() > 0) {
+                strBuilder.append(',');
+            }
+            strBuilder.append(valueItem == null? "" : valueItem.toString());
+        }
+        return strBuilder.toString();
+    }
+
+
+
+    private static void processAllRemainingParametersAsQueryParams(final StringBuilder strBuilder, final Map<String, Object> parameters) {
+
+        final int parameterSize = parameters.size();
+
+        if (parameterSize <= 0) {
+            return;
+        }
+
+        final Set<String> parameterNames = parameters.keySet();
+
+        int i = 0;
+        for (final String parameterName : parameterNames) {
+
+            final Object value = parameters.get(parameterName);
+
+            if (value == null) {
+                if (i > 0) {
+                    strBuilder.append('&');
+                }
+                strBuilder.append(UriEscape.escapeUriQueryParam(parameterName));
+                i++;
+                continue;
+            }
+
+            if (!(value instanceof List<?>)) {
+                if (i > 0) {
+                    strBuilder.append('&');
+                }
+                strBuilder.append(UriEscape.escapeUriQueryParam(parameterName));
+                strBuilder.append('=');
+                strBuilder.append(UriEscape.escapeUriQueryParam(value.toString())); // we know it's not null
+                i++;
+                continue;
+            }
+
+            // It is multivalued, so iterate and process each value
+            final List<?> values = (List<?>)value;
+            final int valuesLen = values.size();
+            for (int j = 0; j < valuesLen; j++) {
+                final Object valueItem = values.get(j);
+                if (i > 0 || j > 0) {
+                    strBuilder.append('&');
+                }
+                strBuilder.append(UriEscape.escapeUriQueryParam(parameterName));
+                if (valueItem != null) {
+                    strBuilder.append('=');
+                    strBuilder.append(UriEscape.escapeUriQueryParam(valueItem.toString()));
+                }
+            }
+
+            i++;
+
+        }
+
+    }
+
+
+    /**
+     * <p>
+     *   Compute the context path to be applied to URLs that have been determined to be context-relative (and therefore
+     *   need a context path to be inserted at their beginning).
+     * </p>
+     * <p>
+     *   By default, this method will obtain the context path from {@code HttpServletRequest.getContextPath()},
+     *   throwing an exception if {@code context} is not an instance of {@code IWebContext} given context-relative
+     *   URLs are (by default) only allowed in web contexts.
+     * </p>
+     * <p>
+     *   This method can be overridden by any subclasses that want to change this behaviour (e.g. in order to
+     *   avoid using the Servlet API for resolving context path or to allow context-relative URLs in non-web
+     *   contexts).
+     * </p>
+     *
+     * @param context the execution context.
+     * @param base the URL base specified.
+     * @param parameters the URL parameters specified.
+     * @return the context path.
+     */
+    protected String computeContextPath(
+            final IExpressionContext context, final String base, final Map<String, Object> parameters) {
+
+        if (!(context instanceof IJakartaWebContext)) {
+            throw new TemplateProcessingException(
+                    "Link base \"" + base + "\" cannot be context relative (/...) unless the context " +
+                    "used for executing the engine implements the " + IJakartaWebContext.class.getName() + " interface");
+        }
+
+        // If it is context-relative, it has to be a web context
+        final HttpServletRequest request = ((IJakartaWebContext)context).getRequest();
+        return request.getContextPath();
+
+    }
+
+
+    /**
+     * <p>
+     *   Process an already-built URL just before returning it.
+     * </p>
+     * <p>
+     *   By default, this method will apply the {@code HttpServletResponse.encodeURL(url)} mechanism, as standard
+     *   when using the Java Servlet API. Note however that this will only be applied if {@code context} is
+     *   an implementation of {@code IWebContext} (i.e. the Servlet API will only be applied in web environments).
+     * </p>
+     * <p>
+     *   This method can be overridden by any subclasses that want to change this behaviour (e.g. in order to
+     *   avoid using the Servlet API).
+     * </p>
+     *
+     * @param context the execution context.
+     * @param link the already-built URL.
+     * @return the processed URL, ready to be used.
+     */
+    protected String processLink(final IExpressionContext context, final String link) {
+
+        if (!(context instanceof IJakartaWebContext)) {
+            return link;
+        }
+
+        final HttpServletResponse response = ((IJakartaWebContext)context).getResponse();
+        return (response != null? response.encodeURL(link) : link);
+
+    }
+
+
+}

--- a/src/main/java/org/thymeleaf/standard/expression/RestrictedJakartaRequestAccessUtils.java
+++ b/src/main/java/org/thymeleaf/standard/expression/RestrictedJakartaRequestAccessUtils.java
@@ -1,0 +1,95 @@
+/*
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2018, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * =============================================================================
+ */
+package org.thymeleaf.standard.expression;
+
+import org.thymeleaf.exceptions.TemplateProcessingException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.util.Map;
+
+/**
+ * <p>
+ *   Utility class that wraps {@link HttpServletRequest} objects in order to restrict access to
+ *   request parameters in specific restricted expression execution environments.
+ * </p>
+ *
+ * @author Daniel Fern&aacute;ndez
+ *
+ * @since 3.0.9
+ *
+ */
+public final class RestrictedJakartaRequestAccessUtils {
+
+
+    public static Object wrapRequestObject(final Object obj) {
+        if (obj == null || !(obj instanceof HttpServletRequest)) {
+            return obj;
+        }
+        return new RestrictedRequestWrapper((HttpServletRequest)obj);
+    }
+
+
+    private RestrictedJakartaRequestAccessUtils() {
+        super();
+    }
+
+
+    /*
+     * This internal class allows the wrapping of the request in RESTRICTED execution environments (like certain
+     * attribute processors) so that no direct access is given to (non-validated) user input like request parameters.
+     */
+    private static class RestrictedRequestWrapper extends HttpServletRequestWrapper {
+
+        public RestrictedRequestWrapper(final HttpServletRequest request) {
+            super(request);
+        }
+
+        @Override
+        public String getParameter(final String name) {
+            throw createRestrictedParameterAccessException();
+        }
+
+        @Override
+        public Map getParameterMap() {
+            throw createRestrictedParameterAccessException();
+        }
+
+        @Override
+        public String[] getParameterValues(final String name) {
+            throw createRestrictedParameterAccessException();
+        }
+
+        @Override
+        public String getQueryString() {
+            throw createRestrictedParameterAccessException();
+        }
+
+        private static TemplateProcessingException createRestrictedParameterAccessException() {
+            return new TemplateProcessingException(
+                    "Access to request parameters is forbidden in this context. Note some restrictions apply to " +
+                    "variable access. For example, direct access to request parameters is forbidden in preprocessing and " +
+                    "unescaped expressions, in TEXT template mode, in fragment insertion specifications and " +
+                    "in some specific attribute processors.");
+        }
+
+    }
+
+}

--- a/src/main/java/org/thymeleaf/templateresolver/JakartaServletContextTemplateResolver.java
+++ b/src/main/java/org/thymeleaf/templateresolver/JakartaServletContextTemplateResolver.java
@@ -1,0 +1,64 @@
+/*
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2018, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * =============================================================================
+ */
+package org.thymeleaf.templateresolver;
+
+import org.thymeleaf.IEngineConfiguration;
+import org.thymeleaf.templateresource.ITemplateResource;
+import org.thymeleaf.templateresource.JakartaServletContextTemplateResource;
+import org.thymeleaf.util.Validate;
+
+import jakarta.servlet.ServletContext;
+import java.util.Map;
+
+/**
+ * <p>
+ *   Implementation of {@link ITemplateResolver} that extends {@link AbstractConfigurableTemplateResolver}
+ *   and creates {@link JakartaServletContextTemplateResource} instances for template resources.
+ * </p>
+ * <p>
+ *   Note a class with this name existed since 1.0, but it was completely rewritten in Thymeleaf 3.0.
+ * </p>
+ *
+ * @author Daniel Fern&aacute;ndez
+ *
+ * @since 3.0.0
+ *
+ */
+public class JakartaServletContextTemplateResolver extends AbstractConfigurableTemplateResolver {
+
+
+    private final ServletContext servletContext;
+
+
+
+    public JakartaServletContextTemplateResolver(final ServletContext servletContext) {
+        super();
+        Validate.notNull(servletContext, "ServletContext cannot be null");
+        this.servletContext = servletContext;
+    }
+
+
+    @Override
+    protected ITemplateResource computeTemplateResource(
+            final IEngineConfiguration configuration, final String ownerTemplate, final String template, final String resourceName, final String characterEncoding, final Map<String, Object> templateResolutionAttributes) {
+        return new JakartaServletContextTemplateResource(this.servletContext, resourceName, characterEncoding);
+    }
+
+}

--- a/src/main/java/org/thymeleaf/templateresource/JakartaServletContextTemplateResource.java
+++ b/src/main/java/org/thymeleaf/templateresource/JakartaServletContextTemplateResource.java
@@ -1,0 +1,129 @@
+/*
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2018, The THYMELEAF team (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * =============================================================================
+ */
+package org.thymeleaf.templateresource;
+
+import org.thymeleaf.util.StringUtils;
+import org.thymeleaf.util.Validate;
+
+import jakarta.servlet.ServletContext;
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.MalformedURLException;
+
+/**
+ * <p>
+ *   Implementation of {@link ITemplateResource} accessible from the {@link ServletContext} in a web application.
+ *   The paths of these resources start at the web application root, and are normally stored inside
+ *   {@code /WEB-INF}.
+ * </p>
+ * <p>
+ *   Objects of this class are usually created by {@link org.thymeleaf.templateresolver.ServletContextTemplateResolver}.
+ * </p>
+ *
+ * @author Daniel Fern&aacute;ndez
+ * @since 3.0.0
+ *
+ */
+public final class JakartaServletContextTemplateResource implements ITemplateResource {
+
+
+    private final ServletContext servletContext;
+    private final String path;
+    private final String characterEncoding;
+
+
+
+    public JakartaServletContextTemplateResource(final ServletContext servletContext, final String path, final String characterEncoding) {
+
+        super();
+
+        Validate.notNull(servletContext, "ServletContext cannot be null");
+        Validate.notEmpty(path, "Resource Path cannot be null or empty");
+        // Character encoding CAN be null (system default will be used)
+
+        this.servletContext = servletContext;
+        final String cleanPath = TemplateResourceUtils.cleanPath(path);
+        this.path = (cleanPath.charAt(0) != '/' ? ("/" + cleanPath) : cleanPath);
+        this.characterEncoding = characterEncoding;
+
+    }
+
+
+
+
+    public String getDescription() {
+        return this.path;
+    }
+
+
+
+
+    public String getBaseName() {
+        return TemplateResourceUtils.computeBaseName(this.path);
+    }
+
+
+
+
+    public Reader reader() throws IOException {
+
+        final InputStream inputStream = this.servletContext.getResourceAsStream(this.path);
+        if (inputStream == null) {
+            throw new FileNotFoundException(String.format("ServletContext resource \"%s\" does not exist", this.path));
+        }
+
+        if (!StringUtils.isEmptyOrWhitespace(this.characterEncoding)) {
+            return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream), this.characterEncoding));
+        }
+
+        return new BufferedReader(new InputStreamReader(new BufferedInputStream(inputStream)));
+
+    }
+
+
+
+
+    public ITemplateResource relative(final String relativeLocation) {
+
+        Validate.notEmpty(relativeLocation, "Relative Path cannot be null or empty");
+
+        final String fullRelativeLocation = TemplateResourceUtils.computeRelativeLocation(this.path, relativeLocation);
+        return new JakartaServletContextTemplateResource(this.servletContext, fullRelativeLocation, this.characterEncoding);
+
+    }
+
+
+
+
+    public boolean exists() {
+        try {
+            return (this.servletContext.getResource(this.path) != null);
+        } catch (final MalformedURLException e) {
+            return false;
+        }
+    }
+
+
+}


### PR DESCRIPTION
This is just a draft as there are bits to sort out. For example, Javadoc cleanup, tests, etc. However, I wanted to get a feel for direction before proceeding much further. There are other PRs for this support, but I think this is a lot more targeted PR around Jakarta Support vs having a lot of additional unrelated changes.

By putting the support in thymeleaf module, we must use JDK 8 to compile because Jakarta EE is JDK 8. Another option would be to place the jakarta support in a separate module. This would allow thymeleaf to continue to be complied as it is today.