### PR TITLE
Remove final from JakartaServletWebApplication and JavaxServletWebApplication for them to be proxyable

### DIFF
--- a/src/main/java/org/thymeleaf/web/servlet/JakartaServletWebApplication.java
+++ b/src/main/java/org/thymeleaf/web/servlet/JakartaServletWebApplication.java
@@ -37,7 +37,7 @@ import org.thymeleaf.util.Validate;
  * @since 3.1.0
  *
  */
-public final class JakartaServletWebApplication implements IServletWebApplication {
+public class JakartaServletWebApplication implements IServletWebApplication {
 
     private final ServletContext servletContext;
 

--- a/src/main/java/org/thymeleaf/web/servlet/JavaxServletWebApplication.java
+++ b/src/main/java/org/thymeleaf/web/servlet/JavaxServletWebApplication.java
@@ -38,7 +38,7 @@ import org.thymeleaf.util.Validate;
  * @since 3.1.0
  *
  */
-public final class JavaxServletWebApplication implements IServletWebApplication {
+public class JavaxServletWebApplication implements IServletWebApplication {
 
     private final ServletContext servletContext;
 


### PR DESCRIPTION
Because Thymeleaf 3.1.0.M1 is compatible with the Jakarta namespace now, [I tried to reactivate the thymeleaf extension in Eclipse Krazo](https://github.com/eclipse-ee4j/krazo/pull/291). 

I tried creating a CDI Producer for `JakartaServletWebApplication`, which failed with the error message that the class is not proxyable. This is because `JakartaServletWebApplication` (and `JavaxServletWebApplication`) are final classes. CDI works by extending the classes and final classes by definition cannot be extended.

As I've explained in [my draft PR in Krazo](https://github.com/eclipse-ee4j/krazo/pull/291#issuecomment-1019566426), I see three possible solutions for this:
> 1. Create a wrapper object for `JakartaServletWebApplication` (in Krazo) and produce that.
> 2. Create an issue/PR with Thymeleaf asking them to remove the final modifier.
> 3. Create an issue/PR with Thymeleaf including the `buildExchange()` method (which we need) in `IServletWebApplication`. That way we could just produce and inject that.
(This would add the need for a wrapper around `HttpServletRequest` and `HttpServletResponse` in Thymeleaf.)

In this PR I've opted for no. 2, because it seams to be both the easiest and cleanest solution.
I've also implemented [no. 3 if you want to take a look](https://github.com/jelemux/thymeleaf/tree/buildexchange_in_iservletwebapplication).