### PR TITLE
Invoke method initializeSpringSpecific at the end of method InitializeSpecific

### DIFF
--- a/lib/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/SpringTemplateEngine.java
+++ b/lib/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/SpringTemplateEngine.java
@@ -279,10 +279,6 @@ public class SpringTemplateEngine
 
     @Override
     protected final void initializeSpecific() {
-
-        // First of all, give the opportunity to subclasses to apply their own configurations
-        initializeSpringSpecific();
-
         // Once the subclasses have had their opportunity, compute configurations belonging to SpringTemplateEngine
         super.initializeSpecific();
 
@@ -300,6 +296,8 @@ public class SpringTemplateEngine
 
         super.setMessageResolver(messageResolver);
 
+        // At last, give the opportunity to subclasses to apply their own configurations
+        initializeSpringSpecific();
     }
 
 


### PR DESCRIPTION
#### What this PR does

Invoke method `initializeSpringSpecific` at the end of method `InitializeSpecific` instead of at the beginning of the method. 

Before doing that, if we want to add a `MessageResolver` into `SpringWebFluxTemplateEngine`, we have to copy full code of `SpringTemplateEngine` and `SpringWebFluxTemplateEngine`.

But After doing that, we can add our own `MessageResolver` into `TemplateEngine` or others. Please see the snippet code below:

```java
public class MySpringWebFluxTemplateEngine extends SpringWebFluxTemplateEngine{

    @Override
    protected void initializeSpringSpecific() {
        addMessageResolver(new MyMessageResolver());
    }
}

```

#### Which issue does this PR fix?

Fix #901 