### PR TITLE
FIX: ThymeleafEvaluationContextACLMethodResolver should call delegate's read method

### DIFF
--- a/lib/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/expression/ThymeleafEvaluationContext.java
+++ b/lib/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/expression/ThymeleafEvaluationContext.java
@@ -36,6 +36,7 @@ import org.springframework.expression.MethodExecutor;
 import org.springframework.expression.MethodResolver;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.TypeLocator;
+import org.springframework.expression.TypedValue;
 import org.springframework.expression.spel.support.ReflectiveMethodResolver;
 import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -244,6 +245,15 @@ public final class ThymeleafEvaluationContext
 
             return canRead;
 
+        }
+
+        @Override
+        public TypedValue read(EvaluationContext context, Object target, String name) throws AccessException {
+            if (this.propertyAccessor != null) {
+                return this.propertyAccessor.read(context, target, name);
+            } else {
+                return super.read(context, target, name);
+            }
         }
 
     }

--- a/lib/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/expression/ThymeleafEvaluationContext.java
+++ b/lib/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/expression/ThymeleafEvaluationContext.java
@@ -36,6 +36,7 @@ import org.springframework.expression.MethodExecutor;
 import org.springframework.expression.MethodResolver;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.TypeLocator;
+import org.springframework.expression.TypedValue;
 import org.springframework.expression.spel.support.ReflectiveMethodResolver;
 import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -244,6 +245,15 @@ public final class ThymeleafEvaluationContext
 
             return canRead;
 
+        }
+
+        @Override
+        public TypedValue read(EvaluationContext context, Object target, String name) throws AccessException {
+            if (this.propertyAccessor != null) {
+                return this.propertyAccessor.read(context, target, name);
+            } else {
+                return super.read(context, target, name);
+            }
         }
 
     }


### PR DESCRIPTION
Hello we have extended the ReflectivePropertyAccessor in our own `EvaluationContext`

So we use `ThymeleafEvaluationContextWrapper(ourEvaluationContext)` and the wrapper itself adds additional wrappers for `propertyAccessors`, `typeLocator` and `methodResolvers`.

In our case `ThymeleafEvaluationContextACLPropertyAccessor` will delegate the `canRead` method, but not the `read` method.

IMHO this is wrong and caused an error in our code.

cheers
Roland


