### PR TITLE
Allow java.util.concurrent.atomic classes in expressions

### DIFF
--- a/lib/thymeleaf/src/main/java/org/thymeleaf/util/ExpressionUtils.java
+++ b/lib/thymeleaf/src/main/java/org/thymeleaf/util/ExpressionUtils.java
@@ -48,6 +48,22 @@ import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicMarkableReference;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.atomic.AtomicStampedReference;
+import java.util.concurrent.atomic.DoubleAccumulator;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -90,6 +106,12 @@ public final class ExpressionUtils {
                     LinkedHashSet.class, Iterator.class, Enumeration.class, Locale.class, Properties.class,
                     Date.class, Calendar.class, Optional.class, OptionalDouble.class, OptionalInt.class,
                     OptionalLong.class, UUID.class,
+                    // java.util.concurrent.atomic
+                    AtomicBoolean.class, AtomicInteger.class, AtomicIntegerArray.class, AtomicIntegerFieldUpdater.class,
+                    AtomicLong.class, AtomicLongArray.class, AtomicLongFieldUpdater.class,
+                    AtomicMarkableReference.class, AtomicReference.class, AtomicReferenceArray.class,
+                    AtomicReferenceFieldUpdater.class, AtomicStampedReference.class, DoubleAccumulator.class,
+                    DoubleAdder.class, LongAccumulator.class, LongAdder.class,
                     // java.sql
                     java.sql.Date.class, Time.class, Timestamp.class));
 

--- a/tests/thymeleaf-tests-core/src/test/java/org/thymeleaf/util/ExpressionUtilsTest.java
+++ b/tests/thymeleaf-tests-core/src/test/java/org/thymeleaf/util/ExpressionUtilsTest.java
@@ -110,6 +110,7 @@ public final class ExpressionUtilsTest {
         Assertions.assertTrue(isTypeAllowed("java.util.stream.Stream"));
         Assertions.assertTrue(isTypeAllowed("java.util.Calendar"));
         Assertions.assertTrue(isTypeAllowed("java.util.Map"));
+        Assertions.assertTrue(isTypeAllowed("java.util.concurrent.atomic.AtomicInteger"));
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/thymeleaf/thymeleaf/issues/1011

If I understand the restrictions correctly, the intention is for higher security of expressions as described in https://github.com/thymeleaf/thymeleaf/issues/871.

And the implementation was changed from block-list to allow-list, as described in https://github.com/thymeleaf/thymeleaf/issues/872

I assume `java.util.concurrent.atomic.***` are safe to be used in expressions, since they are just a value containers like `List` or `Map`, but atomically-accessible.
So this PR adds all atomic classes to the allow-list.