### PR TITLE
Add JDK8-Module Support in StandardJavaScriptSerializer.

### DIFF
--- a/lib/thymeleaf/pom.xml
+++ b/lib/thymeleaf/pom.xml
@@ -130,6 +130,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/lib/thymeleaf/src/main/java/org/thymeleaf/standard/serializer/StandardJavaScriptSerializer.java
+++ b/lib/thymeleaf/src/main/java/org/thymeleaf/standard/serializer/StandardJavaScriptSerializer.java
@@ -180,6 +180,16 @@ public final class StandardJavaScriptSerializer implements IStandardJavaScriptSe
                 }
             }
 
+            final Class<?> jdk8ModuleClass =
+                    ClassLoaderUtils.findClass(jacksonPrefix + ".datatype.jdk8.Jdk8Module");
+            if (jdk8ModuleClass != null) {
+                try {
+                    this.mapper.registerModule((Module)jdk8ModuleClass.newInstance());
+                } catch (final InstantiationException | IllegalAccessException e) {
+                    throw new ConfigurationException("Exception while trying to initialize JDK8Module support for Jackson", e);
+                }
+            }
+
         }
 
 

--- a/tests/thymeleaf-tests-core/src/test/java/org/thymeleaf/standard/serializer/StandardJavaScriptSerializerTest.java
+++ b/tests/thymeleaf-tests-core/src/test/java/org/thymeleaf/standard/serializer/StandardJavaScriptSerializerTest.java
@@ -20,6 +20,9 @@
 package org.thymeleaf.standard.serializer;
 
 import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -159,6 +162,17 @@ public class StandardJavaScriptSerializerTest {
         serializer.serializeValue(VALUE0, stringWriter);
         Assertions.assertEquals("\"<\\/script>\\u0026#22;\"", stringWriter.toString());
 
+    }
+
+    @Test
+    public void testSerializeJdk8OptionalJS() {
+        final IStandardJavaScriptSerializer serializer = new StandardJavaScriptSerializer(true);
+        final StringWriter stringWriter = new StringWriter();
+        Map<String, Optional<String>> map = new HashMap<>();
+        map.put("nonNull", Optional.of("VALUE"));
+        map.put("null", Optional.empty());
+        serializer.serializeValue(map, stringWriter);
+        Assertions.assertEquals("{\"null\":null,\"nonNull\":\"VALUE\"}", stringWriter.toString());
     }
 
 


### PR DESCRIPTION
This PR implements #1023.

Add JDK8-modile Support in StandardJavaScriptSerializer.
