### PR TITLE
feat: improve TextParser error handling

### DIFF
--- a/lib/thymeleaf/src/main/java/org/thymeleaf/templateparser/text/TextParser.java
+++ b/lib/thymeleaf/src/main/java/org/thymeleaf/templateparser/text/TextParser.java
@@ -19,6 +19,8 @@
  */
 package org.thymeleaf.templateparser.text;
 
+import org.thymeleaf.exceptions.TemplateProcessingException;
+
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Arrays;
@@ -232,6 +234,8 @@ final class TextParser {
 
         } catch (final TextParseException e) {
             throw e;
+        } catch (final TemplateProcessingException e) {
+            throw new TextParseException(e, e.getLine(), e.getCol());
         } catch (final Exception e) {
             throw new TextParseException(e);
         } finally {

--- a/tests/thymeleaf-tests-core/src/test/java/org/thymeleaf/parsing/InlinedExpressionParsingErrorsTest.java
+++ b/tests/thymeleaf-tests-core/src/test/java/org/thymeleaf/parsing/InlinedExpressionParsingErrorsTest.java
@@ -1,0 +1,60 @@
+/*
+ * =============================================================================
+ *
+ *   Copyright (c) 2011-2026 Thymeleaf (http://www.thymeleaf.org)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ * =============================================================================
+ */
+package org.thymeleaf.parsing;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.exceptions.TemplateProcessingException;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.StringTemplateResolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class InlinedExpressionParsingErrorsTest {
+
+    final TemplateEngine templateEngine;
+
+    public InlinedExpressionParsingErrorsTest() {
+        final StringTemplateResolver templateResolver = new StringTemplateResolver();
+        templateResolver.setTemplateMode(TemplateMode.TEXT);
+
+        templateEngine = new TemplateEngine();
+        templateEngine.setTemplateResolver(templateResolver);
+    }
+
+    @ParameterizedTest(name = "Should fail validation for malformed expression: {0}")
+    @ValueSource(strings = {
+            "[[${name]]",
+            "[[$name}]]",
+            "[[${)}]]",
+            "[[${@}]]",
+    })
+    void testParsing(String template) {
+
+        final TemplateProcessingException error = assertThrows(TemplateProcessingException.class, () -> templateEngine.process(template, new Context()));
+        assertEquals(1, error.getLine());
+        assertEquals(3, error.getCol());
+
+    }
+
+}


### PR DESCRIPTION
The purpose of this change in `TextParser::parseDocument` method is to catch `TemplateProcessingException` before fallback to generic Exception class in. `TemplateProcessingException` may contain line and column information in its fields, which is easy to access when handling parsing errors.

I stumbled upon this scenario, when building custom validator for end user defined templates in web based editor. In this case, it is important to have line and column where template has errors.
Currently, TextParser looses this information when catching generic Exception.

Currently, Thymeleaf contains 3 exception classes that maintain `line` and `col` information: `TextParseException`, `RawParseException` and `TemplateProcessingException`. 
Another approach could be introducing custom exception class dedicated for containing `line` and `col` properties that could be inherited by those 3 mentioned above, but it would need bigger refactoring.